### PR TITLE
Bundle a service deployer

### DIFF
--- a/lib/monitoring.ts
+++ b/lib/monitoring.ts
@@ -107,15 +107,9 @@ export function createMonitoring(
                     admin: [loadBalancer.admin.loadBalancerArn],
                   },
                   addresses: {
-                    ingress:
-                      props?.monitoring?.dashboard?.controlPanel?.addresses
-                        ?.ingress || loadBalancer.ingress.address,
-                    admin:
-                      props?.monitoring?.dashboard?.controlPanel?.addresses
-                        ?.admin || loadBalancer.admin.address,
-                    webUI:
-                      props?.monitoring?.dashboard?.controlPanel?.addresses
-                        ?.webUI || loadBalancer.webUI.address,
+                    ingress: loadBalancer.ingress.address,
+                    admin: loadBalancer.admin.address,
+                    webUI: loadBalancer.webUI.address,
                   },
                 },
                 networking: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@restatedev/byoc",
       "version": "0.2.0",
       "license": "MIT",
+      "dependencies": {
+        "@restatedev/restate-cdk": "0.0.0-SNAPSHOT-20250521082206"
+      },
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.4",
         "@aws-sdk/client-cloudwatch": "^3.782.0",
@@ -156,14 +159,12 @@
       "version": "2.2.230",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.230.tgz",
       "integrity": "sha512-kUnhKIYu42hqBa6a8x2/7o29ObpJgjYGQy28lZDq9awXyvpR62I2bRxrNKNR3uFUQz3ySuT9JXhGHhuZPdbnFw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.0.tgz",
       "integrity": "sha512-7bY3J8GCVxLupn/kNmpPc5VJz8grx+4RKfnnJiO1LG+uxkZfANZG3RMHhE+qQxxwkyQ9/MfPtTpf748UhR425A==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@aws-cdk/cloud-assembly-schema": {
@@ -174,7 +175,6 @@
         "jsonschema",
         "semver"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "jsonschema": "~1.4.1",
@@ -186,7 +186,6 @@
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
       "version": "1.4.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -195,7 +194,6 @@
     },
     "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
       "version": "7.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -3473,6 +3471,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@restatedev/restate-cdk": {
+      "version": "0.0.0-SNAPSHOT-20250521082206",
+      "resolved": "https://registry.npmjs.org/@restatedev/restate-cdk/-/restate-cdk-0.0.0-SNAPSHOT-20250521082206.tgz",
+      "integrity": "sha512-an3EYXCwm35zc8zAzFtOk60hVRqCYcy3xFk5ddXplpbwdHy4dC0R6yRDjmxLFBBg5739mET9tbWFtwL8Ao6D7g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "aws-cdk": "^2.177.0",
+        "aws-cdk-lib": "^2.177.0",
+        "constructs": "^10.4.0",
+        "node-fetch": "^3.3.2"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -3528,13 +3538,13 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.0.tgz",
-      "integrity": "sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.2.tgz",
+      "integrity": "sha512-7r6mZGwb5LmLJ+zPtkLoznf2EtwEuSWdtid10pjGl/7HefCE4mueOkrfki8JCUm99W6UfP47/r3tbxx9CfBN5A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/types": "^4.2.0",
         "@smithy/util-config-provider": "^4.0.0",
         "@smithy/util-middleware": "^4.0.2",
@@ -3545,13 +3555,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.2.0.tgz",
-      "integrity": "sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.3.2.tgz",
+      "integrity": "sha512-GlLv+syoWolhtjX12XplL9BXBu10cjjD8iQC69fiKTrVNOB3Fjt8CVI9ccm6G3bLbMNe1gzrLD7yyMkYo4hchw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.3",
+        "@smithy/middleware-serde": "^4.0.4",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "@smithy/util-body-length-browser": "^4.0.0",
@@ -3565,13 +3575,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz",
-      "integrity": "sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.4.tgz",
+      "integrity": "sha512-jN6M6zaGVyB8FmNGG+xOPQB4N89M1x97MMdMnm1ESjljLS3Qju/IegQizKujaNcy2vXAvrz0en8bobe6E55FEA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/property-provider": "^4.0.2",
         "@smithy/types": "^4.2.0",
         "@smithy/url-parser": "^4.0.2",
@@ -3754,15 +3764,15 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.0.tgz",
-      "integrity": "sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.5.tgz",
+      "integrity": "sha512-WlpC9KVkajQf7RaGwi3n6lhHZzYTgm2PyX/2JjcwSHG417gFloNmYqN8rzDRXjT527/ZxZuvCsqq1gWZPW8lag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-serde": "^4.0.3",
-        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/core": "^3.3.2",
+        "@smithy/middleware-serde": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/shared-ini-file-loader": "^4.0.2",
         "@smithy/types": "^4.2.0",
         "@smithy/url-parser": "^4.0.2",
@@ -3774,19 +3784,19 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz",
-      "integrity": "sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.6.tgz",
+      "integrity": "sha512-bl8q95nvCf7d22spxsBfs2giUDFf7prWLAxF5tmfgGBYHbUNW+OfnwMnabC15GMLA2AoE4HOtQR18a59lx6Blw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/protocol-http": "^5.1.0",
-        "@smithy/service-error-classification": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/service-error-classification": "^4.0.3",
+        "@smithy/smithy-client": "^4.2.5",
         "@smithy/types": "^4.2.0",
         "@smithy/util-middleware": "^4.0.2",
-        "@smithy/util-retry": "^4.0.2",
+        "@smithy/util-retry": "^4.0.3",
         "tslib": "^2.6.2",
         "uuid": "^9.0.1"
       },
@@ -3795,12 +3805,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
-      "integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.4.tgz",
+      "integrity": "sha512-CaLvBtz+Xgs7eOwoinTXhZ02/9u8b28RT8lQAaDh7Q59nygeYYp1UiJjwl6zsay+lp0qVT/S7qLVI5RgcxjyfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -3823,9 +3834,9 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz",
-      "integrity": "sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.1.tgz",
+      "integrity": "sha512-1slS5jf5icHETwl5hxEVBj+mh6B+LbVW4yRINsGtUKH+nxM5Pw2H59+qf+JqYFCHp9jssG4vX81f5WKnjMN3Vw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3913,9 +3924,9 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.2.tgz",
-      "integrity": "sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.3.tgz",
+      "integrity": "sha512-FTbcajmltovWMjj3tksDQdD23b2w6gH+A0DYA1Yz3iSpjDj8fmkwy62UnXcWMy4d5YoMoSyLFHMfkEVEzbiN8Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3960,14 +3971,14 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.0.tgz",
-      "integrity": "sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==",
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.5.tgz",
+      "integrity": "sha512-T3gA/TShe52Ln0ywWGVoDiqRvaxqvrU0CKRRmzT71/I1rRBD8mY85rvMMME6vw5RpBLJC9ADmXSLmpohF7RRhA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.2.0",
-        "@smithy/middleware-endpoint": "^4.1.0",
+        "@smithy/core": "^3.3.2",
+        "@smithy/middleware-endpoint": "^4.1.5",
         "@smithy/middleware-stack": "^4.0.2",
         "@smithy/protocol-http": "^5.1.0",
         "@smithy/types": "^4.2.0",
@@ -4075,14 +4086,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.8.tgz",
-      "integrity": "sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.13.tgz",
+      "integrity": "sha512-HCLfXAyTEpVWLuyxDABg8UQukeRwChL1UErpSQ4KJK2ZoadmXuQY68pTL9KcuEtasTkIjnzyLUL9vhLdJ3VFHQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/smithy-client": "^4.2.5",
         "@smithy/types": "^4.2.0",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -4092,17 +4103,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz",
-      "integrity": "sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==",
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.13.tgz",
+      "integrity": "sha512-lu8E2RyzKzzFbNu4ICmY/2HltMZlJxMNg3saJ+r8I9vWbWbwdX7GOWUJdP4fbjEOm6aa52mnnd+uIRrT3dNEyA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.1.0",
-        "@smithy/credential-provider-imds": "^4.0.2",
-        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/config-resolver": "^4.1.2",
+        "@smithy/credential-provider-imds": "^4.0.4",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/property-provider": "^4.0.2",
-        "@smithy/smithy-client": "^4.2.0",
+        "@smithy/smithy-client": "^4.2.5",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -4111,13 +4122,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz",
-      "integrity": "sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.4.tgz",
+      "integrity": "sha512-VfFATC1bmZLV2858B/O1NpMcL32wYo8DPPhHxYxDCodDl3f3mSZ5oJheW1IF91A0EeAADz2WsakM/hGGPGNKLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.0.2",
+        "@smithy/node-config-provider": "^4.1.1",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -4153,13 +4164,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.2.tgz",
-      "integrity": "sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.3.tgz",
+      "integrity": "sha512-DPuYjZQDXmKr/sNvy9Spu8R/ESa2e22wXZzSAY6NkjOLj6spbIje/Aq8rT97iUMdDj0qHMRIe+bTxvlU74d9Ng==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.2",
+        "@smithy/service-error-classification": "^4.0.3",
         "@smithy/types": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -4775,7 +4786,6 @@
       "version": "2.1013.0",
       "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1013.0.tgz",
       "integrity": "sha512-cbq4cOoEIZueMWenGgfI4RujS+AQ9GaMCTlW/3CnvEIhMD8j/tgZx7PTtgMuvwYrRoEeb/wTxgLPgUd5FhsoHA==",
-      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
@@ -4804,7 +4814,6 @@
         "yaml",
         "mime-types"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "^2.2.229",
@@ -4831,13 +4840,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/aws-cdk-lib/node_modules/ajv": {
       "version": "8.17.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4853,7 +4860,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4862,7 +4868,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4877,7 +4882,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/astral-regex": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4886,13 +4890,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4902,7 +4904,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/case": {
       "version": "1.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "(MIT OR GPL-3.0-or-later)",
       "engines": {
@@ -4911,7 +4912,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4923,31 +4923,26 @@
     },
     "node_modules/aws-cdk-lib/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/concat-map": {
       "version": "0.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-deep-equal": {
       "version": "3.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/fast-uri": {
       "version": "3.0.6",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4963,7 +4958,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/fs-extra": {
       "version": "11.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4977,13 +4971,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/aws-cdk-lib/node_modules/ignore": {
       "version": "5.3.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4992,7 +4984,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5001,13 +4992,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/json-schema-traverse": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/jsonfile": {
       "version": "6.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5019,7 +5008,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/jsonschema": {
       "version": "1.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5028,13 +5016,11 @@
     },
     "node_modules/aws-cdk-lib/node_modules/lodash.truncate": {
       "version": "4.4.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/aws-cdk-lib/node_modules/mime-db": {
       "version": "1.52.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5043,7 +5029,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/mime-types": {
       "version": "2.1.35",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5055,7 +5040,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/minimatch": {
       "version": "3.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5067,7 +5051,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
       "version": "2.3.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5076,7 +5059,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/require-from-string": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5085,7 +5067,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/semver": {
       "version": "7.7.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -5097,7 +5078,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/slice-ansi": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5114,7 +5094,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5128,7 +5107,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5140,7 +5118,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/table": {
       "version": "6.9.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -5156,7 +5133,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/universalify": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5165,7 +5141,6 @@
     },
     "node_modules/aws-cdk-lib/node_modules/yaml": {
       "version": "1.10.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5633,7 +5608,6 @@
       "version": "10.4.2",
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
       "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {
@@ -5685,6 +5659,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/debug": {
@@ -6276,6 +6260,30 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fflate": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.1.tgz",
@@ -6377,6 +6385,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -6388,7 +6409,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7826,6 +7846,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-emoji": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
@@ -7840,6 +7881,25 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -8955,6 +9015,16 @@
       "license": "Apache-2.0",
       "dependencies": {
         "makeerror": "1.0.12"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -67,5 +67,8 @@
   "peerDependencies": {
     "aws-cdk-lib": "^2.0.0",
     "constructs": "^10.0.0"
+  },
+  "dependencies": {
+    "@restatedev/restate-cdk": "0.0.0-SNAPSHOT-20250521082206"
   }
 }

--- a/test/__snapshots__/byoc.test.ts.snap
+++ b/test/__snapshots__/byoc.test.ts.snap
@@ -200,34 +200,34 @@ exports[`BYOC Default parameters 1`] = `
         - Key: Name
           Value: RestateBYOC/default/shared-nlb
       Type: network
-  defaultingresslistener2DF8DAB9:
+  defaultingresssharedlistener3AB06661:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: defaultingresstargetDADD278C
+            Ref: defaultingresssharedtarget501739FD
           Type: forward
       LoadBalancerArn:
         Ref: defaultsharednlb5E13F2A0
       Port: 8080
       Protocol: TCP
-  defaultadminlistener86103631:
+  defaultadminsharedlistener2B6E2F69:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: defaultadmintarget7DDFAC97
+            Ref: defaultadminsharedtarget04FDBD2A
           Type: forward
       LoadBalancerArn:
         Ref: defaultsharednlb5E13F2A0
       Port: 9070
       Protocol: TCP
-  defaultnodelistener63AFA56F:
+  defaultnodesharedlistenerF94E5381:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: defaultnodetarget96D0F643
+            Ref: defaultnodesharedtarget1C48E466
           Type: forward
       LoadBalancerArn:
         Ref: defaultsharednlb5E13F2A0
@@ -376,15 +376,15 @@ exports[`BYOC Default parameters 1`] = `
         - ContainerName: restate
           ContainerPort: 8080
           TargetGroupArn:
-            Ref: defaultingresstargetDADD278C
+            Ref: defaultingresssharedtarget501739FD
         - ContainerName: restate
           ContainerPort: 9070
           TargetGroupArn:
-            Ref: defaultadmintarget7DDFAC97
+            Ref: defaultadminsharedtarget04FDBD2A
         - ContainerName: restate
           ContainerPort: 5122
           TargetGroupArn:
-            Ref: defaultnodetarget96D0F643
+            Ref: defaultnodesharedtarget1C48E466
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
@@ -403,9 +403,9 @@ exports[`BYOC Default parameters 1`] = `
       TaskDefinition:
         Ref: defaultstatelessdefinitionDCB0B7C0
     DependsOn:
-      - defaultadminlistener86103631
-      - defaultingresslistener2DF8DAB9
-      - defaultnodelistener63AFA56F
+      - defaultadminsharedlistener2B6E2F69
+      - defaultingresssharedlistener3AB06661
+      - defaultnodesharedlistenerF94E5381
       - defaultrestatetaskroleDefaultPolicy58736B8D
       - defaultrestatetaskrole1A7BDFBB
   defaultstatefuldefinition4CD55F35:
@@ -533,7 +533,7 @@ exports[`BYOC Default parameters 1`] = `
           Value: RestateBYOC/default/stateful-definition
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
-  defaultingresstargetDADD278C:
+  defaultingresssharedtarget501739FD:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -545,11 +545,11 @@ exports[`BYOC Default parameters 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/default/ingress-target
+          Value: RestateBYOC/default/ingress-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  defaultadmintarget7DDFAC97:
+  defaultadminsharedtarget04FDBD2A:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -562,11 +562,11 @@ exports[`BYOC Default parameters 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/default/admin-target
+          Value: RestateBYOC/default/admin-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  defaultnodetarget96D0F643:
+  defaultnodesharedtarget1C48E466:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -579,7 +579,7 @@ exports[`BYOC Default parameters 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/default/node-target
+          Value: RestateBYOC/default/node-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
@@ -1803,1216 +1803,7 @@ exports[`BYOC Default parameters 1`] = `
             - >-
               "}}}},"title":"","updateOn":{"refresh":true,"resize":true,"timeRange":true}}}]}
       DashboardName: RestateBYOC_default_control-panel
-"
-`;
-
-exports[`BYOC With alb for admin 1`] = `
-"Resources:
-  alb8A8B13C2:
-    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
-    Properties:
-      LoadBalancerAttributes:
-        - Key: deletion_protection.enabled
-          Value: 'false'
-      Scheme: internal
-      SecurityGroups:
-        - 'Fn::GetAtt':
-            - albSecurityGroup49866104
-            - GroupId
-      Subnets:
-        - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
-        - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
-        - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
-      Type: application
-  albSecurityGroup49866104:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: Automatically created Security Group for ELB RestateBYOCalb8803BD1D
-      SecurityGroupIngress:
-        - CidrIp: 0.0.0.0/0
-          Description: Allow from anyone on port 9070
-          FromPort: 9070
-          IpProtocol: tcp
-          ToPort: 9070
-      VpcId:
-        'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  albSecurityGrouptoRestateBYOCwithadminalbsecuritygroup38D0A92F9070DCBAD672:
-    Type: 'AWS::EC2::SecurityGroupEgress'
-    Properties:
-      Description: Load balancer to target
-      DestinationSecurityGroupId:
-        'Fn::GetAtt':
-          - withadminalbsecuritygroup691AA60B
-          - GroupId
-      FromPort: 9070
-      GroupId:
-        'Fn::GetAtt':
-          - albSecurityGroup49866104
-          - GroupId
-      IpProtocol: tcp
-      ToPort: 9070
-  withadminalbsecuritygroup691AA60B:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: RestateBYOC/with-admin-alb/security-group
-      SecurityGroupEgress:
-        - CidrIp: 0.0.0.0/0
-          Description: Allow all outbound traffic by default
-          IpProtocol: '-1'
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/security-group
-      VpcId:
-        'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withadminalbsecuritygroupfromRestateBYOCwithadminalbsecuritygroup38D0A92F8080522DE27D:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    Properties:
-      Description: 'from RestateBYOCwithadminalbsecuritygroup38D0A92F:8080'
-      FromPort: 8080
-      GroupId:
-        'Fn::GetAtt':
-          - withadminalbsecuritygroup691AA60B
-          - GroupId
-      IpProtocol: tcp
-      SourceSecurityGroupId:
-        'Fn::GetAtt':
-          - withadminalbsecuritygroup691AA60B
-          - GroupId
-      ToPort: 8080
-  withadminalbsecuritygroupfromRestateBYOCwithadminalbsecuritygroup38D0A92F9070E170D1C6:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    Properties:
-      Description: 'from RestateBYOCwithadminalbsecuritygroup38D0A92F:9070'
-      FromPort: 9070
-      GroupId:
-        'Fn::GetAtt':
-          - withadminalbsecuritygroup691AA60B
-          - GroupId
-      IpProtocol: tcp
-      SourceSecurityGroupId:
-        'Fn::GetAtt':
-          - withadminalbsecuritygroup691AA60B
-          - GroupId
-      ToPort: 9070
-  withadminalbsecuritygroupfromRestateBYOCwithadminalbsecuritygroup38D0A92F512202B7F133:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    Properties:
-      Description: 'from RestateBYOCwithadminalbsecuritygroup38D0A92F:5122'
-      FromPort: 5122
-      GroupId:
-        'Fn::GetAtt':
-          - withadminalbsecuritygroup691AA60B
-          - GroupId
-      IpProtocol: tcp
-      SourceSecurityGroupId:
-        'Fn::GetAtt':
-          - withadminalbsecuritygroup691AA60B
-          - GroupId
-      ToPort: 5122
-  withadminalbsecuritygroupfromRestateBYOCalbSecurityGroup357443D59070D67FF84B:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    Properties:
-      Description: Load balancer to target
-      FromPort: 9070
-      GroupId:
-        'Fn::GetAtt':
-          - withadminalbsecuritygroup691AA60B
-          - GroupId
-      IpProtocol: tcp
-      SourceSecurityGroupId:
-        'Fn::GetAtt':
-          - albSecurityGroup49866104
-          - GroupId
-      ToPort: 9070
-  withadminalbbucket3127716F:
-    Type: 'AWS::S3::Bucket'
-    Properties:
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-    UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
-  withadminalbbucketPolicy6B55F590:
-    Type: 'AWS::S3::BucketPolicy'
-    Properties:
-      Bucket:
-        Ref: withadminalbbucket3127716F
-      PolicyDocument:
-        Statement:
-          - Action: 's3:*'
-            Condition:
-              Bool:
-                'aws:SecureTransport': 'false'
-            Effect: Deny
-            Principal:
-              AWS: '*'
-            Resource:
-              - 'Fn::GetAtt':
-                  - withadminalbbucket3127716F
-                  - Arn
-              - 'Fn::Join':
-                  - ''
-                  - - 'Fn::GetAtt':
-                        - withadminalbbucket3127716F
-                        - Arn
-                    - /*
-        Version: '2012-10-17'
-  withadminalbclusterFE2F557B:
-    Type: 'AWS::ECS::Cluster'
-    Properties:
-      ClusterSettings:
-        - Name: containerInsights
-          Value: enhanced
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/cluster
-  withadminalbrestatetaskrole27839A13:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-        Version: '2012-10-17'
-  withadminalbrestatetaskroleDefaultPolicyC6C586B4:
-    Type: 'AWS::IAM::Policy'
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action:
-              - 's3:GetObject'
-              - 's3:PutObject'
-            Effect: Allow
-            Resource:
-              'Fn::Join':
-                - ''
-                - - 'Fn::GetAtt':
-                      - withadminalbbucket3127716F
-                      - Arn
-                  - /*
-            Sid: ReadWriteBucket
-          - Action: 's3:ListBucket'
-            Effect: Allow
-            Resource:
-              'Fn::GetAtt':
-                - withadminalbbucket3127716F
-                - Arn
-            Sid: ListBucket
-        Version: '2012-10-17'
-      PolicyName: withadminalbrestatetaskroleDefaultPolicyC6C586B4
-      Roles:
-        - Ref: withadminalbrestatetaskrole27839A13
-  withadminalbrestateexecutionroleE3DA4130:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-        Version: '2012-10-17'
-  withadminalbrestateexecutionroleDefaultPolicy98A85E6D:
-    Type: 'AWS::IAM::Policy'
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action:
-              - 'logs:CreateLogStream'
-              - 'logs:PutLogEvents'
-            Effect: Allow
-            Resource:
-              'Fn::GetAtt':
-                - withadminalbstatelessdefinitionrestateLogGroupC5F5C91B
-                - Arn
-          - Action:
-              - 'logs:CreateLogStream'
-              - 'logs:PutLogEvents'
-            Effect: Allow
-            Resource:
-              'Fn::GetAtt':
-                - withadminalbstatefuldefinitionrestateLogGroup511AF74E
-                - Arn
-        Version: '2012-10-17'
-      PolicyName: withadminalbrestateexecutionroleDefaultPolicy98A85E6D
-      Roles:
-        - Ref: withadminalbrestateexecutionroleE3DA4130
-  withadminalbadminlistenerCDC56DB9:
-    Type: 'AWS::ElasticLoadBalancingV2::Listener'
-    Properties:
-      DefaultActions:
-        - TargetGroupArn:
-            Ref: withadminalbadmintarget356DA1B2
-          Type: forward
-      LoadBalancerArn:
-        Ref: alb8A8B13C2
-      Port: 9070
-      Protocol: HTTP
-  withadminalbsharednlbA3CC1A58:
-    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
-    Properties:
-      LoadBalancerAttributes:
-        - Key: deletion_protection.enabled
-          Value: 'false'
-        - Key: load_balancing.cross_zone.enabled
-          Value: 'false'
-        - Key: dns_record.client_routing_policy
-          Value: availability_zone_affinity
-      Scheme: internal
-      SecurityGroups:
-        - 'Fn::GetAtt':
-            - withadminalbsecuritygroup691AA60B
-            - GroupId
-      Subnets:
-        - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
-        - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
-        - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/shared-nlb
-      Type: network
-  withadminalbingresslistenerACA09140:
-    Type: 'AWS::ElasticLoadBalancingV2::Listener'
-    Properties:
-      DefaultActions:
-        - TargetGroupArn:
-            Ref: withadminalbingresstarget602F6054
-          Type: forward
-      LoadBalancerArn:
-        Ref: withadminalbsharednlbA3CC1A58
-      Port: 8080
-      Protocol: TCP
-  withadminalbnodelistener4D66F73E:
-    Type: 'AWS::ElasticLoadBalancingV2::Listener'
-    Properties:
-      DefaultActions:
-        - TargetGroupArn:
-            Ref: withadminalbnodetarget17396C8D
-          Type: forward
-      LoadBalancerArn:
-        Ref: withadminalbsharednlbA3CC1A58
-      Port: 5122
-      Protocol: TCP
-  withadminalbstatelessdefinition5CE760F6:
-    Type: 'AWS::ECS::TaskDefinition'
-    Properties:
-      ContainerDefinitions:
-        - Cpu: 16384
-          EntryPoint:
-            - bash
-            - '-c'
-            - >
-
-              curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4/task -o
-              task-metadata && \\
-
-              export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
-                RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Containers[0].Networks[0].IPv4Addresses[0]' task-metadata):5122"
-              exec restate-server
-          Environment:
-            - Name: RESTATE_LOG_FORMAT
-              Value: json
-            - Name: RESTATE_CLUSTER_NAME
-              Value: RestateBYOC/with-admin-alb
-            - Name: RESTATE_ROLES
-              Value: '["admin","http-ingress"]'
-            - Name: RESTATE_AUTO_PROVISION
-              Value: 'true'
-            - Name: RESTATE_SHUTDOWN_TIMEOUT
-              Value: 100s
-            - Name: RESTATE_DEFAULT_NUM_PARTITIONS
-              Value: '128'
-            - Name: RESTATE_DEFAULT_REPLICATION
-              Value: '{zone: 2}'
-            - Name: RESTATE_METADATA_CLIENT__TYPE
-              Value: object-store
-            - Name: RESTATE_METADATA_CLIENT__PATH
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - 's3://'
-                    - Ref: withadminalbbucket3127716F
-                    - /metadata
-            - Name: RESTATE_BIFROST__DEFAULT_PROVIDER
-              Value: replicated
-            - Name: >-
-                RESTATE_INGRESS__EXPERIMENTAL_FEATURE_ENABLE_SEPARATE_INGRESS_ROLE
-              Value: 'true'
-            - Name: RESTATE_INGRESS__ADVERTISED_INGRESS_ENDPOINT
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - 'http://'
-                    - 'Fn::GetAtt':
-                        - withadminalbsharednlbA3CC1A58
-                        - DNSName
-                    - ':8080'
-            - Name: RESTATE_WORKER__SNAPSHOTS__DESTINATION
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - 's3://'
-                    - Ref: withadminalbbucket3127716F
-                    - /snapshots
-          Essential: true
-          HealthCheck:
-            Command:
-              - CMD
-              - curl
-              - '--fail'
-              - 'http://127.0.0.1:8080/restate/health'
-            Interval: 30
-            Retries: 3
-            Timeout: 5
-          Image: Any<Object>
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-group:
-                Ref: withadminalbstatelessdefinitionrestateLogGroupC5F5C91B
-              awslogs-stream-prefix: restate
-              awslogs-region: region
-          Memory: 32768
-          Name: restate
-          PortMappings:
-            - ContainerPort: 8080
-              Name: ingress
-              Protocol: tcp
-            - ContainerPort: 9070
-              Name: admin
-              Protocol: tcp
-            - ContainerPort: 5122
-              Name: node
-              Protocol: tcp
-          StopTimeout: 120
-      Cpu: '16384'
-      ExecutionRoleArn:
-        'Fn::GetAtt':
-          - withadminalbrestateexecutionroleE3DA4130
-          - Arn
-      Family: RestateBYOCwithadminalbstatelessdefinition0DDB981F
-      Memory: '32768'
-      NetworkMode: awsvpc
-      RequiresCompatibilities:
-        - FARGATE
-      RuntimePlatform:
-        CpuArchitecture: ARM64
-        OperatingSystemFamily: LINUX
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/stateless-definition
-      TaskRoleArn:
-        'Fn::GetAtt':
-          - withadminalbrestatetaskrole27839A13
-          - Arn
-  withadminalbstatelessdefinitionrestateLogGroupC5F5C91B:
-    Type: 'AWS::Logs::LogGroup'
-    Properties:
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/stateless-definition
-    UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
-  withadminalbstatelessserviceService6C7E33D7:
-    Type: 'AWS::ECS::Service'
-    Properties:
-      Cluster:
-        Ref: withadminalbclusterFE2F557B
-      DeploymentConfiguration:
-        Alarms:
-          AlarmNames: []
-          Enable: false
-          Rollback: false
-        MaximumPercent: 200
-        MinimumHealthyPercent: 100
-      DesiredCount: 3
-      EnableECSManagedTags: false
-      EnableExecuteCommand: false
-      HealthCheckGracePeriodSeconds: 60
-      LaunchType: FARGATE
-      LoadBalancers:
-        - ContainerName: restate
-          ContainerPort: 8080
-          TargetGroupArn:
-            Ref: withadminalbingresstarget602F6054
-        - ContainerName: restate
-          ContainerPort: 9070
-          TargetGroupArn:
-            Ref: withadminalbadmintarget356DA1B2
-        - ContainerName: restate
-          ContainerPort: 5122
-          TargetGroupArn:
-            Ref: withadminalbnodetarget17396C8D
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
-          SecurityGroups:
-            - 'Fn::GetAtt':
-                - withadminalbsecuritygroup691AA60B
-                - GroupId
-          Subnets:
-            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
-            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
-            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
-      PropagateTags: SERVICE
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/stateless-service
-      TaskDefinition:
-        Ref: withadminalbstatelessdefinition5CE760F6
-    DependsOn:
-      - withadminalbadminlistenerCDC56DB9
-      - withadminalbingresslistenerACA09140
-      - withadminalbnodelistener4D66F73E
-      - withadminalbrestatetaskroleDefaultPolicyC6C586B4
-      - withadminalbrestatetaskrole27839A13
-  withadminalbstatefuldefinition8D9F0FB6:
-    Type: 'AWS::ECS::TaskDefinition'
-    Properties:
-      ContainerDefinitions:
-        - Cpu: 16384
-          EntryPoint:
-            - bash
-            - '-c'
-            - >
-
-              curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4/task -o
-              task-metadata && \\
-
-              export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
-                RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Containers[0].Networks[0].IPv4Addresses[0]' task-metadata):5122"
-              exec restate-server
-          Environment:
-            - Name: RESTATE_LOG_FORMAT
-              Value: json
-            - Name: RESTATE_CLUSTER_NAME
-              Value: RestateBYOC/with-admin-alb
-            - Name: RESTATE_ROLES
-              Value: '["log-server", "worker"]'
-            - Name: RESTATE_AUTO_PROVISION
-              Value: 'false'
-            - Name: RESTATE_SHUTDOWN_TIMEOUT
-              Value: 100s
-            - Name: RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE
-              Value: 24576MiB
-            - Name: RESTATE_METADATA_CLIENT__TYPE
-              Value: object-store
-            - Name: RESTATE_METADATA_CLIENT__PATH
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - 's3://'
-                    - Ref: withadminalbbucket3127716F
-                    - /metadata
-            - Name: RESTATE_WORKER__SNAPSHOTS__DESTINATION
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - 's3://'
-                    - Ref: withadminalbbucket3127716F
-                    - /snapshots
-            - Name: RESTATE_WORKER__SNAPSHOTS__SNAPSHOT_INTERVAL_NUM_RECORDS
-              Value: '1000000'
-            - Name: RESTATE_WORKER__STORAGE__ROCKSDB_DISABLE_DIRECT_IO_FOR_READS
-              Value: 'true'
-            - Name: RESTATE_WORKER__STORAGE__ROCKSDB_DISABLE_WAL_FSYNC
-              Value: 'true'
-            - Name: RESTATE_LOG_SERVER__ROCKSDB_DISABLE_WAL_FSYNC
-              Value: 'true'
-            - Name: RESTATE_LOG_SERVER__ROCKSDB_DISABLE_DIRECT_IO_FOR_READS
-              Value: 'true'
-            - Name: >-
-                RESTATE_INGRESS__EXPERIMENTAL_FEATURE_ENABLE_SEPARATE_INGRESS_ROLE
-              Value: 'true'
-          Essential: true
-          HealthCheck:
-            Command:
-              - CMD
-              - curl
-              - '--fail'
-              - 'http://127.0.0.1:5122/health'
-            Interval: 30
-            Retries: 3
-            Timeout: 5
-          Image: Any<Object>
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-group:
-                Ref: withadminalbstatefuldefinitionrestateLogGroup511AF74E
-              awslogs-stream-prefix: restate
-              awslogs-region: region
-          Memory: 32768
-          MountPoints:
-            - ContainerPath: /restate-data
-              ReadOnly: false
-              SourceVolume: restate-data
-          Name: restate
-          PortMappings:
-            - ContainerPort: 5122
-              Name: node
-              Protocol: tcp
-          RestartPolicy:
-            Enabled: true
-            RestartAttemptPeriod: 60
-          StopTimeout: 120
-      Cpu: '16384'
-      EphemeralStorage:
-        SizeInGiB: 200
-      ExecutionRoleArn:
-        'Fn::GetAtt':
-          - withadminalbrestateexecutionroleE3DA4130
-          - Arn
-      Family: RestateBYOCwithadminalbstatefuldefinition1958C843
-      Memory: '32768'
-      NetworkMode: awsvpc
-      RequiresCompatibilities:
-        - FARGATE
-      RuntimePlatform:
-        CpuArchitecture: ARM64
-        OperatingSystemFamily: LINUX
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/stateful-definition
-      TaskRoleArn:
-        'Fn::GetAtt':
-          - withadminalbrestatetaskrole27839A13
-          - Arn
-      Volumes:
-        - ConfiguredAtLaunch: false
-          Name: restate-data
-  withadminalbstatefuldefinitionrestateLogGroup511AF74E:
-    Type: 'AWS::Logs::LogGroup'
-    Properties:
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/stateful-definition
-    UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
-  withadminalbingresstarget602F6054:
-    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
-    Properties:
-      HealthCheckEnabled: true
-      HealthCheckIntervalSeconds: 5
-      HealthCheckPath: /restate/health
-      HealthCheckProtocol: HTTP
-      HealthCheckTimeoutSeconds: 2
-      Port: 8080
-      Protocol: TCP
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/ingress-target
-      TargetType: ip
-      VpcId:
-        'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withadminalbadmintarget356DA1B2:
-    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
-    Properties:
-      HealthCheckEnabled: true
-      HealthCheckIntervalSeconds: 5
-      HealthCheckPath: /health
-      HealthCheckPort: '9070'
-      HealthCheckProtocol: HTTP
-      HealthCheckTimeoutSeconds: 2
-      Port: 9070
-      Protocol: HTTP
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/admin-target
-      TargetGroupAttributes:
-        - Key: stickiness.enabled
-          Value: 'false'
-      TargetType: ip
-      VpcId:
-        'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withadminalbnodetarget17396C8D:
-    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
-    Properties:
-      HealthCheckEnabled: true
-      HealthCheckIntervalSeconds: 5
-      HealthCheckPath: /health
-      HealthCheckPort: '5122'
-      HealthCheckProtocol: HTTP
-      HealthCheckTimeoutSeconds: 2
-      Port: 5122
-      Protocol: TCP
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/node-target
-      TargetType: ip
-      VpcId:
-        'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withadminalbcontrollertaskroleF7573B6C:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-        Version: '2012-10-17'
-  withadminalbcontrollertaskroleDefaultPolicy67890A1C:
-    Type: 'AWS::IAM::Policy'
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action:
-              - 'ecs:ListTasks'
-              - 'ecs:DescribeTasks'
-              - 'ecs:StopTask'
-            Condition:
-              ArnEquals:
-                'ecs:cluster':
-                  'Fn::GetAtt':
-                    - withadminalbclusterFE2F557B
-                    - Arn
-            Effect: Allow
-            Resource: '*'
-            Sid: TaskActions
-          - Action: 'ecs:TagResource'
-            Effect: Allow
-            Resource:
-              'Fn::Join':
-                - ''
-                - - 'Fn::Join':
-                      - /
-                      - - 'Fn::Join':
-                            - ':'
-                            - - 'Fn::Select':
-                                  - 0
-                                  - 'Fn::Split':
-                                      - ':'
-                                      - 'Fn::Select':
-                                          - 0
-                                          - 'Fn::Split':
-                                              - /
-                                              - 'Fn::GetAtt':
-                                                  - withadminalbclusterFE2F557B
-                                                  - Arn
-                              - 'Fn::Select':
-                                  - 1
-                                  - 'Fn::Split':
-                                      - ':'
-                                      - 'Fn::Select':
-                                          - 0
-                                          - 'Fn::Split':
-                                              - /
-                                              - 'Fn::GetAtt':
-                                                  - withadminalbclusterFE2F557B
-                                                  - Arn
-                              - 'Fn::Select':
-                                  - 2
-                                  - 'Fn::Split':
-                                      - ':'
-                                      - 'Fn::Select':
-                                          - 0
-                                          - 'Fn::Split':
-                                              - /
-                                              - 'Fn::GetAtt':
-                                                  - withadminalbclusterFE2F557B
-                                                  - Arn
-                              - 'Fn::Select':
-                                  - 3
-                                  - 'Fn::Split':
-                                      - ':'
-                                      - 'Fn::Select':
-                                          - 0
-                                          - 'Fn::Split':
-                                              - /
-                                              - 'Fn::GetAtt':
-                                                  - withadminalbclusterFE2F557B
-                                                  - Arn
-                              - 'Fn::Select':
-                                  - 4
-                                  - 'Fn::Split':
-                                      - ':'
-                                      - 'Fn::Select':
-                                          - 0
-                                          - 'Fn::Split':
-                                              - /
-                                              - 'Fn::GetAtt':
-                                                  - withadminalbclusterFE2F557B
-                                                  - Arn
-                              - task
-                        - 'Fn::Select':
-                            - 1
-                            - 'Fn::Split':
-                                - /
-                                - 'Fn::GetAtt':
-                                    - withadminalbclusterFE2F557B
-                                    - Arn
-                        - ''
-                  - '*'
-            Sid: TagTasks
-          - Action: 'ecs:RunTask'
-            Condition:
-              ArnEquals:
-                'ecs:cluster':
-                  'Fn::GetAtt':
-                    - withadminalbclusterFE2F557B
-                    - Arn
-            Effect: Allow
-            Resource:
-              'Fn::Join':
-                - ''
-                - - 'Fn::Join':
-                      - ':'
-                      - - 'Fn::Select':
-                            - 0
-                            - 'Fn::Split':
-                                - ':'
-                                - Ref: withadminalbstatefuldefinition8D9F0FB6
-                        - 'Fn::Select':
-                            - 1
-                            - 'Fn::Split':
-                                - ':'
-                                - Ref: withadminalbstatefuldefinition8D9F0FB6
-                        - 'Fn::Select':
-                            - 2
-                            - 'Fn::Split':
-                                - ':'
-                                - Ref: withadminalbstatefuldefinition8D9F0FB6
-                        - 'Fn::Select':
-                            - 3
-                            - 'Fn::Split':
-                                - ':'
-                                - Ref: withadminalbstatefuldefinition8D9F0FB6
-                        - 'Fn::Select':
-                            - 4
-                            - 'Fn::Split':
-                                - ':'
-                                - Ref: withadminalbstatefuldefinition8D9F0FB6
-                        - 'Fn::Select':
-                            - 5
-                            - 'Fn::Split':
-                                - ':'
-                                - Ref: withadminalbstatefuldefinition8D9F0FB6
-                  - ':*'
-            Sid: RunTask
-          - Action: 'iam:PassRole'
-            Condition:
-              StringEquals:
-                'iam:PassedToService': ecs-tasks.amazonaws.com
-            Effect: Allow
-            Resource:
-              - 'Fn::GetAtt':
-                  - withadminalbrestatetaskrole27839A13
-                  - Arn
-              - 'Fn::GetAtt':
-                  - withadminalbrestateexecutionroleE3DA4130
-                  - Arn
-            Sid: RunTaskPassRole
-          - Action:
-              - 's3:GetObject'
-              - 's3:PutObject'
-            Effect: Allow
-            Resource:
-              'Fn::Join':
-                - ''
-                - - 'Fn::GetAtt':
-                      - withadminalbbucket3127716F
-                      - Arn
-                  - /*
-            Sid: ReadWriteBucket
-          - Action: 's3:ListBucket'
-            Effect: Allow
-            Resource:
-              'Fn::GetAtt':
-                - withadminalbbucket3127716F
-                - Arn
-            Sid: ListBucket
-        Version: '2012-10-17'
-      PolicyName: withadminalbcontrollertaskroleDefaultPolicy67890A1C
-      Roles:
-        - Ref: withadminalbcontrollertaskroleF7573B6C
-  withadminalbcontrollerexecutionrole1054BC08:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service: ecs-tasks.amazonaws.com
-        Version: '2012-10-17'
-  withadminalbcontrollerexecutionroleDefaultPolicy5A74F3CA:
-    Type: 'AWS::IAM::Policy'
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action:
-              - 'logs:CreateLogStream'
-              - 'logs:PutLogEvents'
-            Effect: Allow
-            Resource:
-              'Fn::GetAtt':
-                - withadminalbcontrollerdefinitioncontrollerLogGroupF52F6716
-                - Arn
-        Version: '2012-10-17'
-      PolicyName: withadminalbcontrollerexecutionroleDefaultPolicy5A74F3CA
-      Roles:
-        - Ref: withadminalbcontrollerexecutionrole1054BC08
-  withadminalbcontrollerdefinition4587DB03:
-    Type: 'AWS::ECS::TaskDefinition'
-    Properties:
-      ContainerDefinitions:
-        - Cpu: 1024
-          Environment:
-            - Name: RUST_LOG
-              Value: 'info,restate_fargate_controller=debug'
-            - Name: CONTROLLER_LOG_FORMAT
-              Value: json
-            - Name: CONTROLLER_METADATA_PATH
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - 's3://'
-                    - Ref: withadminalbbucket3127716F
-                    - /metadata
-            - Name: CONTROLLER_RECONCILE_INTERVAL
-              Value: 10s
-            - Name: CONTROLLER_CLUSTER__CLUSTER_ARN
-              Value:
-                'Fn::GetAtt':
-                  - withadminalbclusterFE2F557B
-                  - Arn
-            - Name: CONTROLLER_LICENSE_ID
-              Value: foo
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __REGION
-              Value:
-                Ref: 'AWS::Region'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __CLUSTER_ARN
-              Value:
-                'Fn::GetAtt':
-                  - withadminalbclusterFE2F557B
-                  - Arn
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __TASK_PREFIX
-              Value:
-                'Fn::Join':
-                  - /
-                  - - 'Fn::Join':
-                        - ':'
-                        - - 'Fn::Select':
-                              - 0
-                              - 'Fn::Split':
-                                  - ':'
-                                  - 'Fn::Select':
-                                      - 0
-                                      - 'Fn::Split':
-                                          - /
-                                          - 'Fn::GetAtt':
-                                              - withadminalbclusterFE2F557B
-                                              - Arn
-                          - 'Fn::Select':
-                              - 1
-                              - 'Fn::Split':
-                                  - ':'
-                                  - 'Fn::Select':
-                                      - 0
-                                      - 'Fn::Split':
-                                          - /
-                                          - 'Fn::GetAtt':
-                                              - withadminalbclusterFE2F557B
-                                              - Arn
-                          - 'Fn::Select':
-                              - 2
-                              - 'Fn::Split':
-                                  - ':'
-                                  - 'Fn::Select':
-                                      - 0
-                                      - 'Fn::Split':
-                                          - /
-                                          - 'Fn::GetAtt':
-                                              - withadminalbclusterFE2F557B
-                                              - Arn
-                          - 'Fn::Select':
-                              - 3
-                              - 'Fn::Split':
-                                  - ':'
-                                  - 'Fn::Select':
-                                      - 0
-                                      - 'Fn::Split':
-                                          - /
-                                          - 'Fn::GetAtt':
-                                              - withadminalbclusterFE2F557B
-                                              - Arn
-                          - 'Fn::Select':
-                              - 4
-                              - 'Fn::Split':
-                                  - ':'
-                                  - 'Fn::Select':
-                                      - 0
-                                      - 'Fn::Split':
-                                          - /
-                                          - 'Fn::GetAtt':
-                                              - withadminalbclusterFE2F557B
-                                              - Arn
-                          - task
-                    - 'Fn::Select':
-                        - 1
-                        - 'Fn::Split':
-                            - /
-                            - 'Fn::GetAtt':
-                                - withadminalbclusterFE2F557B
-                                - Arn
-                    - ''
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1a__ENABLE_EXECUTE_COMMAND
-              Value: 'false'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1a__SECURITY_GROUPS
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - '["'
-                    - 'Fn::GetAtt':
-                        - withadminalbsecuritygroup691AA60B
-                        - GroupId
-                    - '"]'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1a__SUBNETS
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - '["'
-                    - 'Fn::ImportValue': >-
-                        VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271
-                    - '"]'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1a__TASK_DEFINITION_ARN
-              Value:
-                Ref: withadminalbstatefuldefinition8D9F0FB6
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1a__COUNT
-              Value: '1'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1b__ENABLE_EXECUTE_COMMAND
-              Value: 'false'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1b__SECURITY_GROUPS
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - '["'
-                    - 'Fn::GetAtt':
-                        - withadminalbsecuritygroup691AA60B
-                        - GroupId
-                    - '"]'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1b__SUBNETS
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - '["'
-                    - 'Fn::ImportValue': >-
-                        VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE
-                    - '"]'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1b__TASK_DEFINITION_ARN
-              Value:
-                Ref: withadminalbstatefuldefinition8D9F0FB6
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1b__COUNT
-              Value: '1'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1c__ENABLE_EXECUTE_COMMAND
-              Value: 'false'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1c__SECURITY_GROUPS
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - '["'
-                    - 'Fn::GetAtt':
-                        - withadminalbsecuritygroup691AA60B
-                        - GroupId
-                    - '"]'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1c__SUBNETS
-              Value:
-                'Fn::Join':
-                  - ''
-                  - - '["'
-                    - 'Fn::ImportValue': >-
-                        VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491
-                    - '"]'
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1c__TASK_DEFINITION_ARN
-              Value:
-                Ref: withadminalbstatefuldefinition8D9F0FB6
-            - Name:
-                'Fn::Join':
-                  - ''
-                  - - CONTROLLER_ECS_CLUSTERS__
-                    - Ref: 'AWS::Region'
-                    - __ZONES__dummy1c__COUNT
-              Value: '1'
-          Essential: true
-          HealthCheck:
-            Command:
-              - CMD
-              - curl
-              - '--fail'
-              - 'http://127.0.0.1:8080/health'
-            Interval: 30
-            Retries: 10
-            StartPeriod: 300
-            Timeout: 5
-          Image: Any<Object>
-          LogConfiguration:
-            LogDriver: awslogs
-            Options:
-              awslogs-group:
-                Ref: withadminalbcontrollerdefinitioncontrollerLogGroupF52F6716
-              awslogs-stream-prefix: controller
-              awslogs-region: region
-          Memory: 2048
-          Name: controller
-          StopTimeout: 120
-      Cpu: '1024'
-      ExecutionRoleArn:
-        'Fn::GetAtt':
-          - withadminalbcontrollerexecutionrole1054BC08
-          - Arn
-      Family: RestateBYOCwithadminalbcontrollerdefinition22C370A0
-      Memory: '2048'
-      NetworkMode: awsvpc
-      RequiresCompatibilities:
-        - FARGATE
-      RuntimePlatform:
-        CpuArchitecture: ARM64
-        OperatingSystemFamily: LINUX
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/controller-definition
-      TaskRoleArn:
-        'Fn::GetAtt':
-          - withadminalbcontrollertaskroleF7573B6C
-          - Arn
-  withadminalbcontrollerdefinitioncontrollerLogGroupF52F6716:
-    Type: 'AWS::Logs::LogGroup'
-    Properties:
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/controller-definition
-    UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
-  withadminalbcontrollerserviceServiceCC3E3695:
-    Type: 'AWS::ECS::Service'
-    Properties:
-      Cluster:
-        Ref: withadminalbclusterFE2F557B
-      DeploymentConfiguration:
-        Alarms:
-          AlarmNames: []
-          Enable: false
-          Rollback: false
-        MaximumPercent: 100
-        MinimumHealthyPercent: 0
-      DesiredCount: 1
-      EnableECSManagedTags: false
-      EnableExecuteCommand: false
-      LaunchType: FARGATE
-      NetworkConfiguration:
-        AwsvpcConfiguration:
-          AssignPublicIp: DISABLED
-          SecurityGroups:
-            - 'Fn::GetAtt':
-                - withadminalbsecuritygroup691AA60B
-                - GroupId
-          Subnets:
-            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
-            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
-            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/controller-service
-      TaskDefinition:
-        Ref: withadminalbcontrollerdefinition4587DB03
-    DependsOn:
-      - withadminalbcontrollertaskroleDefaultPolicy67890A1C
-      - withadminalbcontrollertaskroleF7573B6C
-  withadminalbrestatectllambdaexecutionroleF5EF50CC:
+  defaultservicedeployerlambdaexecutionrole6140D796:
     Type: 'AWS::IAM::Role'
     Properties:
       AssumeRolePolicyDocument:
@@ -3022,7 +1813,7 @@ exports[`BYOC With alb for admin 1`] = `
             Principal:
               Service: lambda.amazonaws.com
         Version: '2012-10-17'
-  withadminalbrestatectllambdaexecutionroleDefaultPolicy13FEA449:
+  defaultservicedeployerlambdaexecutionroleDefaultPolicy09E0E938:
     Type: 'AWS::IAM::Policy'
     Properties:
       PolicyDocument:
@@ -3041,635 +1832,50 @@ exports[`BYOC With alb for admin 1`] = `
             Resource: '*'
             Sid: AWSLambdaVPCAccessExecutionPermissions
         Version: '2012-10-17'
-      PolicyName: withadminalbrestatectllambdaexecutionroleDefaultPolicy13FEA449
+      PolicyName: defaultservicedeployerlambdaexecutionroleDefaultPolicy09E0E938
       Roles:
-        - Ref: withadminalbrestatectllambdaexecutionroleF5EF50CC
-  withadminalbrestatectllambda34B68249:
+        - Ref: defaultservicedeployerlambdaexecutionrole6140D796
+  defaultservicedeployerEventHandler07D0FC10:
     Type: 'AWS::Lambda::Function'
     Properties:
       Architectures:
         - arm64
       Code: Any<Object>
+      Description: Restate custom registration handler
       Environment:
         Variables:
-          RESTATECTL_ADDRESS:
-            'Fn::Join':
-              - ''
-              - - 'http://'
-                - 'Fn::GetAtt':
-                    - withadminalbsharednlbA3CC1A58
-                    - DNSName
-                - ':5122'
-      Handler: restatectl
+          NODE_OPTIONS: '--enable-source-maps'
+      Handler: entrypoint.handler
+      MemorySize: 128
       Role:
         'Fn::GetAtt':
-          - withadminalbrestatectllambdaexecutionroleF5EF50CC
+          - defaultservicedeployerlambdaexecutionrole6140D796
           - Arn
-      Runtime: provided.al2023
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/restatectl-lambda
-      Timeout: 10
+      Runtime: nodejs22.x
+      Timeout: 180
       VpcConfig:
         SecurityGroupIds:
           - 'Fn::GetAtt':
-              - withadminalbsecuritygroup691AA60B
+              - defaultsecuritygroupE8DEFA55
               - GroupId
         SubnetIds:
           - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
           - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
           - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
     DependsOn:
-      - withadminalbrestatectllambdaexecutionroleDefaultPolicy13FEA449
-      - withadminalbrestatectllambdaexecutionroleF5EF50CC
-  withadminalbretirementwatcherlambdaexecutionroleB9A1C9EF:
-    Type: 'AWS::IAM::Role'
+      - defaultservicedeployerlambdaexecutionroleDefaultPolicy09E0E938
+      - defaultservicedeployerlambdaexecutionrole6140D796
+  defaultservicedeployerDeploymentLogs01FFFB9F:
+    Type: 'AWS::Logs::LogGroup'
     Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-        Version: '2012-10-17'
-  withadminalbretirementwatcherlambdaexecutionroleDefaultPolicy0774DAD2:
-    Type: 'AWS::IAM::Policy'
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action:
-              - 'logs:CreateLogGroup'
-              - 'logs:CreateLogStream'
-              - 'logs:PutLogEvents'
-            Effect: Allow
-            Resource: '*'
-            Sid: AWSLambdaBasicExecutionPermissions
-          - Action: 'ecs:TagResource'
-            Effect: Allow
-            Resource:
-              'Fn::Join':
-                - ''
-                - - 'Fn::Join':
-                      - /
-                      - - 'Fn::Join':
-                            - ':'
-                            - - 'Fn::Select':
-                                  - 0
-                                  - 'Fn::Split':
-                                      - ':'
-                                      - 'Fn::Select':
-                                          - 0
-                                          - 'Fn::Split':
-                                              - /
-                                              - 'Fn::GetAtt':
-                                                  - withadminalbclusterFE2F557B
-                                                  - Arn
-                              - 'Fn::Select':
-                                  - 1
-                                  - 'Fn::Split':
-                                      - ':'
-                                      - 'Fn::Select':
-                                          - 0
-                                          - 'Fn::Split':
-                                              - /
-                                              - 'Fn::GetAtt':
-                                                  - withadminalbclusterFE2F557B
-                                                  - Arn
-                              - 'Fn::Select':
-                                  - 2
-                                  - 'Fn::Split':
-                                      - ':'
-                                      - 'Fn::Select':
-                                          - 0
-                                          - 'Fn::Split':
-                                              - /
-                                              - 'Fn::GetAtt':
-                                                  - withadminalbclusterFE2F557B
-                                                  - Arn
-                              - 'Fn::Select':
-                                  - 3
-                                  - 'Fn::Split':
-                                      - ':'
-                                      - 'Fn::Select':
-                                          - 0
-                                          - 'Fn::Split':
-                                              - /
-                                              - 'Fn::GetAtt':
-                                                  - withadminalbclusterFE2F557B
-                                                  - Arn
-                              - 'Fn::Select':
-                                  - 4
-                                  - 'Fn::Split':
-                                      - ':'
-                                      - 'Fn::Select':
-                                          - 0
-                                          - 'Fn::Split':
-                                              - /
-                                              - 'Fn::GetAtt':
-                                                  - withadminalbclusterFE2F557B
-                                                  - Arn
-                              - task
-                        - 'Fn::Select':
-                            - 1
-                            - 'Fn::Split':
-                                - /
-                                - 'Fn::GetAtt':
-                                    - withadminalbclusterFE2F557B
-                                    - Arn
-                        - ''
-                  - '*'
-            Sid: TagTasks
-          - Action:
-              - 'sqs:ReceiveMessage'
-              - 'sqs:ChangeMessageVisibility'
-              - 'sqs:GetQueueUrl'
-              - 'sqs:DeleteMessage'
-              - 'sqs:GetQueueAttributes'
-            Effect: Allow
-            Resource:
-              'Fn::GetAtt':
-                - withadminalbretirementwatcherqueue59FD1C98
-                - Arn
-        Version: '2012-10-17'
-      PolicyName: withadminalbretirementwatcherlambdaexecutionroleDefaultPolicy0774DAD2
-      Roles:
-        - Ref: withadminalbretirementwatcherlambdaexecutionroleB9A1C9EF
-  withadminalbretirementwatcherlambda27645E72:
-    Type: 'AWS::Lambda::Function'
-    Properties:
-      Architectures:
-        - arm64
-      Code: Any<Object>
-      Handler: index.handler
-      Role:
-        'Fn::GetAtt':
-          - withadminalbretirementwatcherlambdaexecutionroleB9A1C9EF
-          - Arn
-      Runtime: nodejs22.x
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/retirement-watcher-lambda
-      Timeout: 60
-    DependsOn:
-      - withadminalbretirementwatcherlambdaexecutionroleDefaultPolicy0774DAD2
-      - withadminalbretirementwatcherlambdaexecutionroleB9A1C9EF
-  withadminalbretirementwatcherlambdaSqsEventSourceRestateBYOCwithadminalbretirementwatcherqueue1CA958C35A146A97:
-    Type: 'AWS::Lambda::EventSourceMapping'
-    Properties:
-      BatchSize: 1
-      EventSourceArn:
-        'Fn::GetAtt':
-          - withadminalbretirementwatcherqueue59FD1C98
-          - Arn
-      FunctionName:
-        Ref: withadminalbretirementwatcherlambda27645E72
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/retirement-watcher-lambda
-  withadminalbretirementwatcherqueue59FD1C98:
-    Type: 'AWS::SQS::Queue'
-    Properties:
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/retirement-watcher-queue
-      VisibilityTimeout: 60
-    UpdateReplacePolicy: Delete
-    DeletionPolicy: Delete
-  withadminalbretirementwatcherqueuePolicyDF3DFF6E:
-    Type: 'AWS::SQS::QueuePolicy'
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action:
-              - 'sqs:SendMessage'
-              - 'sqs:GetQueueAttributes'
-              - 'sqs:GetQueueUrl'
-            Condition:
-              ArnEquals:
-                'aws:SourceArn':
-                  'Fn::GetAtt':
-                    - withadminalbretirementwatcherruleAC7EAF0B
-                    - Arn
-            Effect: Allow
-            Principal:
-              Service: events.amazonaws.com
-            Resource:
-              'Fn::GetAtt':
-                - withadminalbretirementwatcherqueue59FD1C98
-                - Arn
-        Version: '2012-10-17'
-      Queues:
-        - Ref: withadminalbretirementwatcherqueue59FD1C98
-  withadminalbretirementwatcherruleAC7EAF0B:
-    Type: 'AWS::Events::Rule'
-    Properties:
-      EventPattern:
-        detail:
-          eventTypeCode:
-            - equals-ignore-case: AWS_ECS_TASK_PATCHING_RETIREMENT
-          service:
-            - equals-ignore-case: ecs
-        resources:
-          - prefix:
-              'Fn::Join':
-                - /
-                - - 'Fn::Join':
-                      - ':'
-                      - - 'Fn::Select':
-                            - 0
-                            - 'Fn::Split':
-                                - ':'
-                                - 'Fn::Select':
-                                    - 0
-                                    - 'Fn::Split':
-                                        - /
-                                        - 'Fn::GetAtt':
-                                            - withadminalbclusterFE2F557B
-                                            - Arn
-                        - 'Fn::Select':
-                            - 1
-                            - 'Fn::Split':
-                                - ':'
-                                - 'Fn::Select':
-                                    - 0
-                                    - 'Fn::Split':
-                                        - /
-                                        - 'Fn::GetAtt':
-                                            - withadminalbclusterFE2F557B
-                                            - Arn
-                        - 'Fn::Select':
-                            - 2
-                            - 'Fn::Split':
-                                - ':'
-                                - 'Fn::Select':
-                                    - 0
-                                    - 'Fn::Split':
-                                        - /
-                                        - 'Fn::GetAtt':
-                                            - withadminalbclusterFE2F557B
-                                            - Arn
-                        - 'Fn::Select':
-                            - 3
-                            - 'Fn::Split':
-                                - ':'
-                                - 'Fn::Select':
-                                    - 0
-                                    - 'Fn::Split':
-                                        - /
-                                        - 'Fn::GetAtt':
-                                            - withadminalbclusterFE2F557B
-                                            - Arn
-                        - 'Fn::Select':
-                            - 4
-                            - 'Fn::Split':
-                                - ':'
-                                - 'Fn::Select':
-                                    - 0
-                                    - 'Fn::Split':
-                                        - /
-                                        - 'Fn::GetAtt':
-                                            - withadminalbclusterFE2F557B
-                                            - Arn
-                        - task
-                  - 'Fn::Select':
-                      - 1
-                      - 'Fn::Split':
-                          - /
-                          - 'Fn::GetAtt':
-                              - withadminalbclusterFE2F557B
-                              - Arn
-                  - ''
-        detail-type:
-          - equals-ignore-case: AWS Health Event
-      State: ENABLED
-      Targets:
-        - Arn:
-            'Fn::GetAtt':
-              - withadminalbretirementwatcherqueue59FD1C98
-              - Arn
-          Id: Target0
-  withadminalbcloudwatchcustomwidgetexecutionrole03452F4D:
-    Type: 'AWS::IAM::Role'
-    Properties:
-      AssumeRolePolicyDocument:
-        Statement:
-          - Action: 'sts:AssumeRole'
-            Effect: Allow
-            Principal:
-              Service: lambda.amazonaws.com
-        Version: '2012-10-17'
-  withadminalbcloudwatchcustomwidgetexecutionroleDefaultPolicyCB2CD0F3:
-    Type: 'AWS::IAM::Policy'
-    Properties:
-      PolicyDocument:
-        Statement:
-          - Action:
-              - 'logs:CreateLogGroup'
-              - 'logs:CreateLogStream'
-              - 'logs:PutLogEvents'
-            Effect: Allow
-            Resource: '*'
-            Sid: AWSLambdaBasicExecutionPermissions
-          - Action: 'lambda:InvokeFunction'
-            Effect: Allow
-            Resource:
-              'Fn::GetAtt':
-                - withadminalbrestatectllambda34B68249
-                - Arn
-            Sid: InvokeRestatectl
-          - Action:
-              - 'ec2:DescribeVolumes'
-              - 'ec2:DescribeVolumeStatus'
-            Effect: Allow
-            Resource: '*'
-            Sid: EC2ReadActions
-          - Action: 'ecs:DescribeTaskDefinition'
-            Effect: Allow
-            Resource: '*'
-            Sid: ECSReadActions
-          - Action: 'ecs:ListTasks'
-            Condition:
-              StringEquals:
-                'ecs:cluster':
-                  'Fn::GetAtt':
-                    - withadminalbclusterFE2F557B
-                    - Arn
-            Effect: Allow
-            Resource: '*'
-            Sid: ECSListTasks
-          - Action: 'ecs:DescribeTasks'
-            Condition:
-              StringEquals:
-                'ecs:cluster':
-                  'Fn::GetAtt':
-                    - withadminalbclusterFE2F557B
-                    - Arn
-            Effect: Allow
-            Resource:
-              'Fn::Join':
-                - ''
-                - - 'arn:'
-                  - Ref: 'AWS::Partition'
-                  - ':ecs:'
-                  - Ref: 'AWS::Region'
-                  - ':'
-                  - Ref: 'AWS::AccountId'
-                  - ':task/'
-                  - Ref: withadminalbclusterFE2F557B
-                  - /*
-            Sid: ECSDescribeTasks
-          - Action: 'ecs:DescribeServices'
-            Condition:
-              StringEquals:
-                'ecs:cluster':
-                  'Fn::GetAtt':
-                    - withadminalbclusterFE2F557B
-                    - Arn
-            Effect: Allow
-            Resource:
-              'Fn::Join':
-                - ''
-                - - 'arn:'
-                  - Ref: 'AWS::Partition'
-                  - ':ecs:'
-                  - Ref: 'AWS::Region'
-                  - ':'
-                  - Ref: 'AWS::AccountId'
-                  - ':service/'
-                  - Ref: withadminalbclusterFE2F557B
-                  - /*
-            Sid: ECSDescribeServices
-          - Action: 'cloudwatch:GetMetricData'
-            Effect: Allow
-            Resource: '*'
-            Sid: CloudWatchReadActions
-        Version: '2012-10-17'
-      PolicyName: withadminalbcloudwatchcustomwidgetexecutionroleDefaultPolicyCB2CD0F3
-      Roles:
-        - Ref: withadminalbcloudwatchcustomwidgetexecutionrole03452F4D
-  withadminalbcloudwatchcustomwidgetlambda0D98751A:
-    Type: 'AWS::Lambda::Function'
-    Properties:
-      Architectures:
-        - arm64
-      Code: Any<Object>
-      Handler: index.handler
-      MemorySize: 1024
-      Role:
-        'Fn::GetAtt':
-          - withadminalbcloudwatchcustomwidgetexecutionrole03452F4D
-          - Arn
-      Runtime: nodejs22.x
-      Tags:
-        - Key: Name
-          Value: RestateBYOC/with-admin-alb/cloudwatch-custom-widget-lambda
-      Timeout: 60
-    DependsOn:
-      - withadminalbcloudwatchcustomwidgetexecutionroleDefaultPolicyCB2CD0F3
-      - withadminalbcloudwatchcustomwidgetexecutionrole03452F4D
-  withadminalbcloudwatchcustomwidgetlambdacloudwatchcustomwidgetlambdaallowdatasource83CBEF48:
-    Type: 'AWS::Lambda::Permission'
-    Properties:
-      Action: 'lambda:InvokeFunction'
-      FunctionName:
-        'Fn::GetAtt':
-          - withadminalbcloudwatchcustomwidgetlambda0D98751A
-          - Arn
-      Principal: lambda.datasource.cloudwatch.amazonaws.com
-  withadminalbmetrics70EAA505:
-    Type: 'AWS::CloudWatch::Dashboard'
-    Properties:
-      DashboardBody:
+      LogGroupName:
         'Fn::Join':
           - ''
-          - - >-
-              {"widgets":[{"type":"metric","width":12,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Stateless
-              CPU","region":"
-            - Ref: 'AWS::Region'
-            - >-
-              ","metrics":[[{"label":"CPU","expression":"cpu /
-              1024"}],[{"expression":"SELECT AVG(CpuUtilized) FROM
-              SCHEMA(\\"ECS/ContainerInsights\\",
-              ClusterName,TaskDefinitionFamily,TaskId) WHERE
-              TaskDefinitionFamily =
-              'RestateBYOCwithadminalbstatelessdefinition0DDB981F' GROUP BY
-              TaskId","visible":false,"id":"cpu"}]],"annotations":{"horizontal":[{"value":16,"label":"Limit","yAxis":"left"}]},"yAxis":{"left":{"label":"vCPUs","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"Stateless
-              Memory","region":"
-            - Ref: 'AWS::Region'
-            - >-
-              ","metrics":[[{"label":"Memory","expression":"memory /
-              1024"}],[{"expression":"SELECT AVG(MemoryUtilized) FROM
-              SCHEMA(\\"ECS/ContainerInsights\\",
-              ClusterName,TaskDefinitionFamily,TaskId) WHERE
-              TaskDefinitionFamily =
-              'RestateBYOCwithadminalbstatelessdefinition0DDB981F' GROUP BY
-              TaskId","visible":false,"id":"memory"}]],"annotations":{"horizontal":[{"value":32,"label":"Limit","yAxis":"left"}]},"yAxis":{"left":{"label":"GiB","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Stateless
-              Network Tx","region":"
-            - Ref: 'AWS::Region'
-            - >-
-              ","metrics":[[{"label":"Tx","expression":"SELECT
-              AVG(NetworkTxBytes) FROM SCHEMA(\\"ECS/ContainerInsights\\",
-              ClusterName,TaskDefinitionFamily,TaskId) WHERE
-              TaskDefinitionFamily =
-              'RestateBYOCwithadminalbstatelessdefinition0DDB981F' GROUP BY
-              TaskId"}]],"yAxis":{"left":{"label":"Bytes/sec","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":6,"properties":{"view":"timeSeries","title":"Stateless
-              Network Rx","region":"
-            - Ref: 'AWS::Region'
-            - >-
-              ","metrics":[[{"label":"Rx","expression":"SELECT
-              AVG(NetworkRxBytes) FROM SCHEMA(\\"ECS/ContainerInsights\\",
-              ClusterName,TaskDefinitionFamily,TaskId) WHERE
-              TaskDefinitionFamily =
-              'RestateBYOCwithadminalbstatelessdefinition0DDB981F' GROUP BY
-              TaskId"}]],"yAxis":{"left":{"label":"Bytes/sec","showUnits":false}}}},{"type":"log","width":24,"height":6,"x":0,"y":12,"properties":{"view":"table","title":"Stateless
-              Logs","region":"region","query":"SOURCE '
-            - Ref: withadminalbstatelessdefinitionrestateLogGroupC5F5C91B
-            - >-
-              ' | fields @logStream, @timestamp, level, fields.message,
-              target\\n          | sort @timestamp desc\\n          | limit
-              500"}},{"type":"metric","width":12,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Stateful
-              CPU","region":"
-            - Ref: 'AWS::Region'
-            - >-
-              ","metrics":[[{"label":"CPU","expression":"cpu /
-              1024"}],[{"expression":"SELECT AVG(CpuUtilized) FROM
-              SCHEMA(\\"ECS/ContainerInsights\\",
-              ClusterName,TaskDefinitionFamily,TaskId) WHERE
-              TaskDefinitionFamily =
-              'RestateBYOCwithadminalbstatefuldefinition1958C843' GROUP BY
-              TaskId","visible":false,"id":"cpu"}]],"annotations":{"horizontal":[{"value":16,"label":"Limit","yAxis":"left"}]},"yAxis":{"left":{"label":"vCPUs","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":18,"properties":{"view":"timeSeries","title":"Stateful
-              Memory","region":"
-            - Ref: 'AWS::Region'
-            - >-
-              ","metrics":[[{"label":"Memory","expression":"memory /
-              1024"}],[{"expression":"SELECT AVG(MemoryUtilized) FROM
-              SCHEMA(\\"ECS/ContainerInsights\\",
-              ClusterName,TaskDefinitionFamily,TaskId) WHERE
-              TaskDefinitionFamily =
-              'RestateBYOCwithadminalbstatefuldefinition1958C843' GROUP BY
-              TaskId","visible":false,"id":"memory"}]],"annotations":{"horizontal":[{"value":32,"label":"Limit","yAxis":"left"}]},"yAxis":{"left":{"label":"GiB","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Stateful
-              Network Tx","region":"
-            - Ref: 'AWS::Region'
-            - >-
-              ","metrics":[[{"label":"Tx","expression":"SELECT
-              AVG(NetworkTxBytes) FROM SCHEMA(\\"ECS/ContainerInsights\\",
-              ClusterName,TaskDefinitionFamily,TaskId) WHERE
-              TaskDefinitionFamily =
-              'RestateBYOCwithadminalbstatefuldefinition1958C843' GROUP BY
-              TaskId"}]],"yAxis":{"left":{"label":"Bytes/sec","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":24,"properties":{"view":"timeSeries","title":"Stateful
-              Network Rx","region":"
-            - Ref: 'AWS::Region'
-            - >-
-              ","metrics":[[{"label":"Rx","expression":"SELECT
-              AVG(NetworkRxBytes) FROM SCHEMA(\\"ECS/ContainerInsights\\",
-              ClusterName,TaskDefinitionFamily,TaskId) WHERE
-              TaskDefinitionFamily =
-              'RestateBYOCwithadminalbstatefuldefinition1958C843' GROUP BY
-              TaskId"}]],"yAxis":{"left":{"label":"Bytes/sec","showUnits":false}}}},{"type":"log","width":24,"height":6,"x":0,"y":30,"properties":{"view":"table","title":"Stateful
-              Logs","region":"region","query":"SOURCE '
-            - Ref: withadminalbstatefuldefinitionrestateLogGroup511AF74E
-            - >-
-              ' | fields @logStream, @timestamp, level, fields.message,
-              target\\n          | sort @timestamp desc\\n          | limit
-              500"}},{"type":"metric","width":8,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"Ephemeral
-              Volume Usage (Total size 200GiB)","region":"
-            - Ref: 'AWS::Region'
-            - >-
-              ","metrics":[[{"label":"Usage","expression":"SELECT
-              MAX(EphemeralStorageUtilized) FROM
-              SCHEMA(\\"ECS/ContainerInsights\\",
-              ClusterName,TaskDefinitionFamily) WHERE TaskDefinitionFamily =
-              'RestateBYOCwithadminalbstatefuldefinition1958C843'"}]],"annotations":{"horizontal":[{"value":200,"label":"Volume
-              size","visible":false,"yAxis":"left"}]},"yAxis":{"left":{"label":"GiB","showUnits":false}},"liveData":false}},{"type":"metric","width":8,"height":6,"x":8,"y":36,"properties":{"view":"timeSeries","title":"Volume
-              Write Throughput (Limited to 150 MiB/sec)","region":"
-            - Ref: 'AWS::Region'
-            - >-
-              ","metrics":[[{"label":"Write","expression":"RATE(count) /
-              1048576"}],[{"expression":"SELECT MAX(StorageWriteBytes) FROM
-              SCHEMA(\\"ECS/ContainerInsights\\",
-              ClusterName,TaskDefinitionFamily,TaskId) WHERE
-              TaskDefinitionFamily =
-              'RestateBYOCwithadminalbstatefuldefinition1958C843' GROUP BY
-              TaskId","visible":false,"id":"count"}]],"annotations":{"horizontal":[{"value":150,"label":"Limit","visible":false,"yAxis":"left"}]},"yAxis":{"left":{"label":"MiB/sec","showUnits":false}}}},{"type":"metric","width":8,"height":6,"x":16,"y":36,"properties":{"view":"timeSeries","title":"Volume
-              Read Throughput (Limited to 150 MiB/sec)","region":"
-            - Ref: 'AWS::Region'
-            - >-
-              ","metrics":[[{"label":"Read","expression":"RATE(count) /
-              1048576"}],[{"expression":"SELECT MAX(StorageReadBytes) FROM
-              SCHEMA(\\"ECS/ContainerInsights\\",
-              ClusterName,TaskDefinitionFamily,TaskId) WHERE
-              TaskDefinitionFamily =
-              'RestateBYOCwithadminalbstatefuldefinition1958C843' GROUP BY
-              TaskId","visible":false,"id":"count"}]],"annotations":{"horizontal":[{"value":150,"label":"Limit","visible":false,"yAxis":"left"}]},"yAxis":{"left":{"label":"MiB/sec","showUnits":false}}}},{"type":"log","width":24,"height":6,"x":0,"y":42,"properties":{"view":"table","title":"Controller
-              Logs","region":"region","query":"SOURCE '
-            - Ref: withadminalbcontrollerdefinitioncontrollerLogGroupF52F6716
-            - >-
-              ' | fields @logStream, @timestamp, level, fields.message,
-              target\\n          | sort @timestamp desc\\n          | limit
-              500"}}]}
-      DashboardName: RestateBYOC_with-admin-alb_metrics
-  withadminalbcontrolpanel306ACD5F:
-    Type: 'AWS::CloudWatch::Dashboard'
-    Properties:
-      DashboardBody:
-        'Fn::Join':
-          - ''
-          - - >-
-              {"widgets":[{"type":"custom","width":24,"height":26,"x":0,"y":0,"properties":{"endpoint":"
-            - 'Fn::GetAtt':
-                - withadminalbcloudwatchcustomwidgetlambda0D98751A
-                - Arn
-            - '","params":{"command":"controlPanel","input":{"region":"'
-            - Ref: 'AWS::Region'
-            - >-
-              ","summary":{"clusterName":"RestateBYOC/with-admin-alb","restateVersion":"1.3","stackVersion":"0.2.0","metricsDashboardName":"
-            - Ref: withadminalbmetrics70EAA505
-            - '"},"resources":{"ecsClusterArn":"'
-            - 'Fn::GetAtt':
-                - withadminalbclusterFE2F557B
-                - Arn
-            - '","statelessServiceArn":"'
-            - Ref: withadminalbstatelessserviceService6C7E33D7
-            - '","controllerServiceArn":"'
-            - Ref: withadminalbcontrollerserviceServiceCC3E3695
-            - '","restatectlLambdaArn":"'
-            - 'Fn::GetAtt':
-                - withadminalbrestatectllambda34B68249
-                - Arn
-            - >-
-              "},"connectivityAndSecurity":{"connectivity":{"loadBalancerArns":{"ingress":["
-            - Ref: withadminalbsharednlbA3CC1A58
-            - '"],"admin":["'
-            - Ref: alb8A8B13C2
-            - '"]},"addresses":{"ingress":"http://'
-            - 'Fn::GetAtt':
-                - withadminalbsharednlbA3CC1A58
-                - DNSName
-            - ':8080","admin":"http://'
-            - 'Fn::GetAtt':
-                - alb8A8B13C2
-                - DNSName
-            - ':9070","webUI":"http://'
-            - 'Fn::GetAtt':
-                - alb8A8B13C2
-                - DNSName
-            - ':9070/ui"}},"networking":{"vpc":"'
-            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-            - '","availabilityZones":["dummy1a","dummy1b","dummy1c"],"subnets":["'
-            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
-            - '","'
-            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
-            - '","'
-            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
-            - '"]},"security":{"securityGroups":["'
-            - 'Fn::GetAtt':
-                - withadminalbsecuritygroup691AA60B
-                - GroupId
-            - '"]}},"storage":{"s3":{"bucket":"'
-            - Ref: withadminalbbucket3127716F
-            - >-
-              "}}}},"title":"","updateOn":{"refresh":true,"resize":true,"timeRange":true}}}]}
-      DashboardName: RestateBYOC_with-admin-alb_control-panel
+          - - /aws/lambda/
+            - Ref: defaultservicedeployerEventHandler07D0FC10
+      RetentionInDays: 30
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
 "
 `;
 
@@ -3871,34 +2077,34 @@ exports[`BYOC With one az 1`] = `
         - Key: Name
           Value: RestateBYOC/one-az/shared-nlb
       Type: network
-  oneazingresslistener6F0223F2:
+  oneazingresssharedlistener65EA2978:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: oneazingresstarget406F98A3
+            Ref: oneazingresssharedtarget87A44DD7
           Type: forward
       LoadBalancerArn:
         Ref: oneazsharednlb21F0A25A
       Port: 8080
       Protocol: TCP
-  oneazadminlistener2E944D68:
+  oneazadminsharedlistenerA70D0F28:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: oneazadmintargetBDBAC1F7
+            Ref: oneazadminsharedtarget813446FE
           Type: forward
       LoadBalancerArn:
         Ref: oneazsharednlb21F0A25A
       Port: 9070
       Protocol: TCP
-  oneaznodelistener166E25F0:
+  oneaznodesharedlistener633B0D1E:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: oneaznodetarget4177E6ED
+            Ref: oneaznodesharedtarget4E3E63D0
           Type: forward
       LoadBalancerArn:
         Ref: oneazsharednlb21F0A25A
@@ -4047,15 +2253,15 @@ exports[`BYOC With one az 1`] = `
         - ContainerName: restate
           ContainerPort: 8080
           TargetGroupArn:
-            Ref: oneazingresstarget406F98A3
+            Ref: oneazingresssharedtarget87A44DD7
         - ContainerName: restate
           ContainerPort: 9070
           TargetGroupArn:
-            Ref: oneazadmintargetBDBAC1F7
+            Ref: oneazadminsharedtarget813446FE
         - ContainerName: restate
           ContainerPort: 5122
           TargetGroupArn:
-            Ref: oneaznodetarget4177E6ED
+            Ref: oneaznodesharedtarget4E3E63D0
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
@@ -4072,9 +2278,9 @@ exports[`BYOC With one az 1`] = `
       TaskDefinition:
         Ref: oneazstatelessdefinition33395BD6
     DependsOn:
-      - oneazadminlistener2E944D68
-      - oneazingresslistener6F0223F2
-      - oneaznodelistener166E25F0
+      - oneazadminsharedlistenerA70D0F28
+      - oneazingresssharedlistener65EA2978
+      - oneaznodesharedlistener633B0D1E
       - oneazrestatetaskroleDefaultPolicy75353BFC
       - oneazrestatetaskroleED26DCA9
   oneazstatefuldefinition8395A3A6:
@@ -4202,7 +2408,7 @@ exports[`BYOC With one az 1`] = `
           Value: RestateBYOC/one-az/stateful-definition
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
-  oneazingresstarget406F98A3:
+  oneazingresssharedtarget87A44DD7:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -4214,11 +2420,11 @@ exports[`BYOC With one az 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/one-az/ingress-target
+          Value: RestateBYOC/one-az/ingress-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  oneazadmintargetBDBAC1F7:
+  oneazadminsharedtarget813446FE:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -4231,11 +2437,11 @@ exports[`BYOC With one az 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/one-az/admin-target
+          Value: RestateBYOC/one-az/admin-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  oneaznodetarget4177E6ED:
+  oneaznodesharedtarget4E3E63D0:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -4248,7 +2454,7 @@ exports[`BYOC With one az 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/one-az/node-target
+          Value: RestateBYOC/one-az/node-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
@@ -5366,6 +3572,77 @@ exports[`BYOC With one az 1`] = `
             - >-
               "}}}},"title":"","updateOn":{"refresh":true,"resize":true,"timeRange":true}}}]}
       DashboardName: RestateBYOC_one-az_control-panel
+  oneazservicedeployerlambdaexecutionroleBCB2D253:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+  oneazservicedeployerlambdaexecutionroleDefaultPolicy6F5E3F27:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+              - 'ec2:CreateNetworkInterface'
+              - 'ec2:DescribeNetworkInterfaces'
+              - 'ec2:DescribeSubnets'
+              - 'ec2:DeleteNetworkInterface'
+              - 'ec2:AssignPrivateIpAddresses'
+              - 'ec2:UnassignPrivateIpAddresses'
+            Effect: Allow
+            Resource: '*'
+            Sid: AWSLambdaVPCAccessExecutionPermissions
+        Version: '2012-10-17'
+      PolicyName: oneazservicedeployerlambdaexecutionroleDefaultPolicy6F5E3F27
+      Roles:
+        - Ref: oneazservicedeployerlambdaexecutionroleBCB2D253
+  oneazservicedeployerEventHandler6219458C:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Architectures:
+        - arm64
+      Code: Any<Object>
+      Description: Restate custom registration handler
+      Environment:
+        Variables:
+          NODE_OPTIONS: '--enable-source-maps'
+      Handler: entrypoint.handler
+      MemorySize: 128
+      Role:
+        'Fn::GetAtt':
+          - oneazservicedeployerlambdaexecutionroleBCB2D253
+          - Arn
+      Runtime: nodejs22.x
+      Timeout: 180
+      VpcConfig:
+        SecurityGroupIds:
+          - 'Fn::GetAtt':
+              - oneazsecuritygroup3EBC43A7
+              - GroupId
+        SubnetIds:
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
+    DependsOn:
+      - oneazservicedeployerlambdaexecutionroleDefaultPolicy6F5E3F27
+      - oneazservicedeployerlambdaexecutionroleBCB2D253
+  oneazservicedeployerDeploymentLogs843ED89D:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName:
+        'Fn::Join':
+          - ''
+          - - /aws/lambda/
+            - Ref: oneazservicedeployerEventHandler6219458C
+      RetentionInDays: 30
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
 "
 `;
 
@@ -5682,34 +3959,34 @@ exports[`BYOC With shared alb 1`] = `
           - GroupId
       IpProtocol: tcp
       ToPort: 5122
-  withsharedalbingresslistener9B834A62:
+  withsharedalbingresssharedlistenerC5DBBAEA:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withsharedalbingresstarget2860B6C5
+            Ref: withsharedalbingresssharedtarget7AF31D75
           Type: forward
       LoadBalancerArn:
         Ref: withsharedalb7F233835
       Port: 8080
       Protocol: HTTP
-  withsharedalbadminlistener237C480F:
+  withsharedalbadminsharedlistener58F44365:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withsharedalbadmintargetA338A1D0
+            Ref: withsharedalbadminsharedtargetEC422D18
           Type: forward
       LoadBalancerArn:
         Ref: withsharedalb7F233835
       Port: 9070
       Protocol: HTTP
-  withsharedalbnodelistener4A43EDA2:
+  withsharedalbnodesharedlistener638EC249:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withsharedalbnodetarget36EE4682
+            Ref: withsharedalbnodesharedtarget238B77F4
           Type: forward
       LoadBalancerArn:
         Ref: withsharedalb7F233835
@@ -5858,15 +4135,15 @@ exports[`BYOC With shared alb 1`] = `
         - ContainerName: restate
           ContainerPort: 8080
           TargetGroupArn:
-            Ref: withsharedalbingresstarget2860B6C5
+            Ref: withsharedalbingresssharedtarget7AF31D75
         - ContainerName: restate
           ContainerPort: 9070
           TargetGroupArn:
-            Ref: withsharedalbadmintargetA338A1D0
+            Ref: withsharedalbadminsharedtargetEC422D18
         - ContainerName: restate
           ContainerPort: 5122
           TargetGroupArn:
-            Ref: withsharedalbnodetarget36EE4682
+            Ref: withsharedalbnodesharedtarget238B77F4
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
@@ -5885,9 +4162,9 @@ exports[`BYOC With shared alb 1`] = `
       TaskDefinition:
         Ref: withsharedalbstatelessdefinition9EFE894B
     DependsOn:
-      - withsharedalbadminlistener237C480F
-      - withsharedalbingresslistener9B834A62
-      - withsharedalbnodelistener4A43EDA2
+      - withsharedalbadminsharedlistener58F44365
+      - withsharedalbingresssharedlistenerC5DBBAEA
+      - withsharedalbnodesharedlistener638EC249
       - withsharedalbrestatetaskroleDefaultPolicy3C4A4214
       - withsharedalbrestatetaskroleDE0CA1F2
   withsharedalbstatefuldefinitionD5488E14:
@@ -6015,7 +4292,7 @@ exports[`BYOC With shared alb 1`] = `
           Value: RestateBYOC/with-shared-alb/stateful-definition
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
-  withsharedalbingresstarget2860B6C5:
+  withsharedalbingresssharedtarget7AF31D75:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -6027,14 +4304,14 @@ exports[`BYOC With shared alb 1`] = `
       Protocol: HTTP
       Tags:
         - Key: Name
-          Value: RestateBYOC/with-shared-alb/ingress-target
+          Value: RestateBYOC/with-shared-alb/ingress-shared-target
       TargetGroupAttributes:
         - Key: stickiness.enabled
           Value: 'false'
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withsharedalbadmintargetA338A1D0:
+  withsharedalbadminsharedtargetEC422D18:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -6047,14 +4324,14 @@ exports[`BYOC With shared alb 1`] = `
       Protocol: HTTP
       Tags:
         - Key: Name
-          Value: RestateBYOC/with-shared-alb/admin-target
+          Value: RestateBYOC/with-shared-alb/admin-shared-target
       TargetGroupAttributes:
         - Key: stickiness.enabled
           Value: 'false'
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withsharedalbnodetarget36EE4682:
+  withsharedalbnodesharedtarget238B77F4:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -6067,7 +4344,7 @@ exports[`BYOC With shared alb 1`] = `
       Protocol: HTTP
       Tags:
         - Key: Name
-          Value: RestateBYOC/with-shared-alb/node-target
+          Value: RestateBYOC/with-shared-alb/node-shared-target
       TargetGroupAttributes:
         - Key: stickiness.enabled
           Value: 'false'
@@ -7294,6 +5571,79 @@ exports[`BYOC With shared alb 1`] = `
             - >-
               "}}}},"title":"","updateOn":{"refresh":true,"resize":true,"timeRange":true}}}]}
       DashboardName: RestateBYOC_with-shared-alb_control-panel
+  withsharedalbservicedeployerlambdaexecutionrole3C2BA824:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+  withsharedalbservicedeployerlambdaexecutionroleDefaultPolicy35179AC3:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+              - 'ec2:CreateNetworkInterface'
+              - 'ec2:DescribeNetworkInterfaces'
+              - 'ec2:DescribeSubnets'
+              - 'ec2:DeleteNetworkInterface'
+              - 'ec2:AssignPrivateIpAddresses'
+              - 'ec2:UnassignPrivateIpAddresses'
+            Effect: Allow
+            Resource: '*'
+            Sid: AWSLambdaVPCAccessExecutionPermissions
+        Version: '2012-10-17'
+      PolicyName: withsharedalbservicedeployerlambdaexecutionroleDefaultPolicy35179AC3
+      Roles:
+        - Ref: withsharedalbservicedeployerlambdaexecutionrole3C2BA824
+  withsharedalbservicedeployerEventHandler08B36F69:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Architectures:
+        - arm64
+      Code: Any<Object>
+      Description: Restate custom registration handler
+      Environment:
+        Variables:
+          NODE_OPTIONS: '--enable-source-maps'
+      Handler: entrypoint.handler
+      MemorySize: 128
+      Role:
+        'Fn::GetAtt':
+          - withsharedalbservicedeployerlambdaexecutionrole3C2BA824
+          - Arn
+      Runtime: nodejs22.x
+      Timeout: 180
+      VpcConfig:
+        SecurityGroupIds:
+          - 'Fn::GetAtt':
+              - withsharedalbsecuritygroup764E6947
+              - GroupId
+        SubnetIds:
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
+    DependsOn:
+      - withsharedalbservicedeployerlambdaexecutionroleDefaultPolicy35179AC3
+      - withsharedalbservicedeployerlambdaexecutionrole3C2BA824
+  withsharedalbservicedeployerDeploymentLogsF669CD11:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName:
+        'Fn::Join':
+          - ''
+          - - /aws/lambda/
+            - Ref: withsharedalbservicedeployerEventHandler08B36F69
+      RetentionInDays: 30
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
 "
 `;
 
@@ -7497,34 +5847,34 @@ exports[`BYOC With volume 1`] = `
         - Key: Name
           Value: RestateBYOC/with-volume/shared-nlb
       Type: network
-  withvolumeingresslistener2D5D7322:
+  withvolumeingresssharedlistener5D7C7189:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withvolumeingresstargetA62E21B6
+            Ref: withvolumeingresssharedtarget52F4AFDA
           Type: forward
       LoadBalancerArn:
         Ref: withvolumesharednlb4B8218D2
       Port: 8080
       Protocol: TCP
-  withvolumeadminlistener4C20C306:
+  withvolumeadminsharedlistenerB71D0323:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withvolumeadmintarget0B4A76B1
+            Ref: withvolumeadminsharedtargetDB9B03BE
           Type: forward
       LoadBalancerArn:
         Ref: withvolumesharednlb4B8218D2
       Port: 9070
       Protocol: TCP
-  withvolumenodelistener00762A68:
+  withvolumenodesharedlistener3FFE0F43:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withvolumenodetargetA7E04507
+            Ref: withvolumenodesharedtarget2EC7A630
           Type: forward
       LoadBalancerArn:
         Ref: withvolumesharednlb4B8218D2
@@ -7673,15 +6023,15 @@ exports[`BYOC With volume 1`] = `
         - ContainerName: restate
           ContainerPort: 8080
           TargetGroupArn:
-            Ref: withvolumeingresstargetA62E21B6
+            Ref: withvolumeingresssharedtarget52F4AFDA
         - ContainerName: restate
           ContainerPort: 9070
           TargetGroupArn:
-            Ref: withvolumeadmintarget0B4A76B1
+            Ref: withvolumeadminsharedtargetDB9B03BE
         - ContainerName: restate
           ContainerPort: 5122
           TargetGroupArn:
-            Ref: withvolumenodetargetA7E04507
+            Ref: withvolumenodesharedtarget2EC7A630
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
@@ -7700,9 +6050,9 @@ exports[`BYOC With volume 1`] = `
       TaskDefinition:
         Ref: withvolumestatelessdefinition6EEBEF17
     DependsOn:
-      - withvolumeadminlistener4C20C306
-      - withvolumeingresslistener2D5D7322
-      - withvolumenodelistener00762A68
+      - withvolumeadminsharedlistenerB71D0323
+      - withvolumeingresssharedlistener5D7C7189
+      - withvolumenodesharedlistener3FFE0F43
       - withvolumerestatetaskroleDefaultPolicyB2F6578B
       - withvolumerestatetaskroleEAE4F95E
   withvolumestatefuldefinitionF7A5C84B:
@@ -7828,7 +6178,7 @@ exports[`BYOC With volume 1`] = `
           Value: RestateBYOC/with-volume/stateful-definition
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
-  withvolumeingresstargetA62E21B6:
+  withvolumeingresssharedtarget52F4AFDA:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -7840,11 +6190,11 @@ exports[`BYOC With volume 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/with-volume/ingress-target
+          Value: RestateBYOC/with-volume/ingress-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withvolumeadmintarget0B4A76B1:
+  withvolumeadminsharedtargetDB9B03BE:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -7857,11 +6207,11 @@ exports[`BYOC With volume 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/with-volume/admin-target
+          Value: RestateBYOC/with-volume/admin-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withvolumenodetargetA7E04507:
+  withvolumenodesharedtarget2EC7A630:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -7874,7 +6224,7 @@ exports[`BYOC With volume 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/with-volume/node-target
+          Value: RestateBYOC/with-volume/node-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
@@ -8649,6 +6999,8 @@ exports[`BYOC With volume 1`] = `
       Tags:
         - Key: Name
           Value: RestateBYOC/with-volume/volume-role
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
   withvolumecontrollerserviceService047527E7:
     Type: 'AWS::ECS::Service'
     Properties:
@@ -9361,6 +7713,79 @@ exports[`BYOC With volume 1`] = `
             - >-
               "}}}},"title":"","updateOn":{"refresh":true,"resize":true,"timeRange":true}}}]}
       DashboardName: RestateBYOC_with-volume_control-panel
+  withvolumeservicedeployerlambdaexecutionroleAC3EC425:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+  withvolumeservicedeployerlambdaexecutionroleDefaultPolicy28D741ED:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+              - 'ec2:CreateNetworkInterface'
+              - 'ec2:DescribeNetworkInterfaces'
+              - 'ec2:DescribeSubnets'
+              - 'ec2:DeleteNetworkInterface'
+              - 'ec2:AssignPrivateIpAddresses'
+              - 'ec2:UnassignPrivateIpAddresses'
+            Effect: Allow
+            Resource: '*'
+            Sid: AWSLambdaVPCAccessExecutionPermissions
+        Version: '2012-10-17'
+      PolicyName: withvolumeservicedeployerlambdaexecutionroleDefaultPolicy28D741ED
+      Roles:
+        - Ref: withvolumeservicedeployerlambdaexecutionroleAC3EC425
+  withvolumeservicedeployerEventHandlerC7B60E7B:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Architectures:
+        - arm64
+      Code: Any<Object>
+      Description: Restate custom registration handler
+      Environment:
+        Variables:
+          NODE_OPTIONS: '--enable-source-maps'
+      Handler: entrypoint.handler
+      MemorySize: 128
+      Role:
+        'Fn::GetAtt':
+          - withvolumeservicedeployerlambdaexecutionroleAC3EC425
+          - Arn
+      Runtime: nodejs22.x
+      Timeout: 180
+      VpcConfig:
+        SecurityGroupIds:
+          - 'Fn::GetAtt':
+              - withvolumesecuritygroup6DBAA33E
+              - GroupId
+        SubnetIds:
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
+    DependsOn:
+      - withvolumeservicedeployerlambdaexecutionroleDefaultPolicy28D741ED
+      - withvolumeservicedeployerlambdaexecutionroleAC3EC425
+  withvolumeservicedeployerDeploymentLogsFDDBA0DC:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName:
+        'Fn::Join':
+          - ''
+          - - /aws/lambda/
+            - Ref: withvolumeservicedeployerEventHandlerC7B60E7B
+      RetentionInDays: 30
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
 "
 `;
 
@@ -9564,34 +7989,34 @@ exports[`BYOC Without control panel 1`] = `
         - Key: Name
           Value: RestateBYOC/without-control-panel/shared-nlb
       Type: network
-  withoutcontrolpanelingresslistenerDE3411C1:
+  withoutcontrolpanelingresssharedlistener2A10FF3E:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withoutcontrolpanelingresstarget4101A351
+            Ref: withoutcontrolpanelingresssharedtarget040A5A44
           Type: forward
       LoadBalancerArn:
         Ref: withoutcontrolpanelsharednlb68A27AF0
       Port: 8080
       Protocol: TCP
-  withoutcontrolpaneladminlistenerCF3C6288:
+  withoutcontrolpaneladminsharedlistener23DDE4FD:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withoutcontrolpaneladmintargetB8FE56E8
+            Ref: withoutcontrolpaneladminsharedtargetBE291FE8
           Type: forward
       LoadBalancerArn:
         Ref: withoutcontrolpanelsharednlb68A27AF0
       Port: 9070
       Protocol: TCP
-  withoutcontrolpanelnodelistener12780111:
+  withoutcontrolpanelnodesharedlistenerF5D548C2:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withoutcontrolpanelnodetarget24D91CC0
+            Ref: withoutcontrolpanelnodesharedtarget4C2992DD
           Type: forward
       LoadBalancerArn:
         Ref: withoutcontrolpanelsharednlb68A27AF0
@@ -9740,15 +8165,15 @@ exports[`BYOC Without control panel 1`] = `
         - ContainerName: restate
           ContainerPort: 8080
           TargetGroupArn:
-            Ref: withoutcontrolpanelingresstarget4101A351
+            Ref: withoutcontrolpanelingresssharedtarget040A5A44
         - ContainerName: restate
           ContainerPort: 9070
           TargetGroupArn:
-            Ref: withoutcontrolpaneladmintargetB8FE56E8
+            Ref: withoutcontrolpaneladminsharedtargetBE291FE8
         - ContainerName: restate
           ContainerPort: 5122
           TargetGroupArn:
-            Ref: withoutcontrolpanelnodetarget24D91CC0
+            Ref: withoutcontrolpanelnodesharedtarget4C2992DD
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
@@ -9767,9 +8192,9 @@ exports[`BYOC Without control panel 1`] = `
       TaskDefinition:
         Ref: withoutcontrolpanelstatelessdefinition28C4C08C
     DependsOn:
-      - withoutcontrolpaneladminlistenerCF3C6288
-      - withoutcontrolpanelingresslistenerDE3411C1
-      - withoutcontrolpanelnodelistener12780111
+      - withoutcontrolpaneladminsharedlistener23DDE4FD
+      - withoutcontrolpanelingresssharedlistener2A10FF3E
+      - withoutcontrolpanelnodesharedlistenerF5D548C2
       - withoutcontrolpanelrestatetaskroleDefaultPolicyF992A460
       - withoutcontrolpanelrestatetaskroleFF8DB8FE
   withoutcontrolpanelstatefuldefinitionB19B8DF2:
@@ -9897,7 +8322,7 @@ exports[`BYOC Without control panel 1`] = `
           Value: RestateBYOC/without-control-panel/stateful-definition
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
-  withoutcontrolpanelingresstarget4101A351:
+  withoutcontrolpanelingresssharedtarget040A5A44:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -9909,11 +8334,11 @@ exports[`BYOC Without control panel 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/without-control-panel/ingress-target
+          Value: RestateBYOC/without-control-panel/ingress-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withoutcontrolpaneladmintargetB8FE56E8:
+  withoutcontrolpaneladminsharedtargetBE291FE8:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -9926,11 +8351,11 @@ exports[`BYOC Without control panel 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/without-control-panel/admin-target
+          Value: RestateBYOC/without-control-panel/admin-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withoutcontrolpanelnodetarget24D91CC0:
+  withoutcontrolpanelnodesharedtarget4C2992DD:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -9943,7 +8368,7 @@ exports[`BYOC Without control panel 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/without-control-panel/node-target
+          Value: RestateBYOC/without-control-panel/node-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
@@ -11128,6 +9553,81 @@ exports[`BYOC Without control panel 1`] = `
               target\\n          | sort @timestamp desc\\n          | limit
               500"}}]}
       DashboardName: RestateBYOC_without-control-panel_metrics
+  withoutcontrolpanelservicedeployerlambdaexecutionroleDF352819:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+  withoutcontrolpanelservicedeployerlambdaexecutionroleDefaultPolicy6C7E48F1:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+              - 'ec2:CreateNetworkInterface'
+              - 'ec2:DescribeNetworkInterfaces'
+              - 'ec2:DescribeSubnets'
+              - 'ec2:DeleteNetworkInterface'
+              - 'ec2:AssignPrivateIpAddresses'
+              - 'ec2:UnassignPrivateIpAddresses'
+            Effect: Allow
+            Resource: '*'
+            Sid: AWSLambdaVPCAccessExecutionPermissions
+        Version: '2012-10-17'
+      PolicyName: >-
+        withoutcontrolpanelservicedeployerlambdaexecutionroleDefaultPolicy6C7E48F1
+      Roles:
+        - Ref: withoutcontrolpanelservicedeployerlambdaexecutionroleDF352819
+  withoutcontrolpanelservicedeployerEventHandler07AAAD8B:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Architectures:
+        - arm64
+      Code: Any<Object>
+      Description: Restate custom registration handler
+      Environment:
+        Variables:
+          NODE_OPTIONS: '--enable-source-maps'
+      Handler: entrypoint.handler
+      MemorySize: 128
+      Role:
+        'Fn::GetAtt':
+          - withoutcontrolpanelservicedeployerlambdaexecutionroleDF352819
+          - Arn
+      Runtime: nodejs22.x
+      Timeout: 180
+      VpcConfig:
+        SecurityGroupIds:
+          - 'Fn::GetAtt':
+              - withoutcontrolpanelsecuritygroup442A1897
+              - GroupId
+        SubnetIds:
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
+    DependsOn:
+      - >-
+        withoutcontrolpanelservicedeployerlambdaexecutionroleDefaultPolicy6C7E48F1
+      - withoutcontrolpanelservicedeployerlambdaexecutionroleDF352819
+  withoutcontrolpanelservicedeployerDeploymentLogs005D410A:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName:
+        'Fn::Join':
+          - ''
+          - - /aws/lambda/
+            - Ref: withoutcontrolpanelservicedeployerEventHandler07AAAD8B
+      RetentionInDays: 30
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
 "
 `;
 
@@ -11333,34 +9833,34 @@ exports[`BYOC Without custom widget lambda 1`] = `
         - Key: Name
           Value: RestateBYOC/without-custom-widget-lambda/shared-nlb
       Type: network
-  withoutcustomwidgetlambdaingresslistener54C2C8B1:
+  withoutcustomwidgetlambdaingresssharedlistener1C15A3B8:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withoutcustomwidgetlambdaingresstarget4AD70E49
+            Ref: withoutcustomwidgetlambdaingresssharedtarget4513DA2B
           Type: forward
       LoadBalancerArn:
         Ref: withoutcustomwidgetlambdasharednlbB2365ABF
       Port: 8080
       Protocol: TCP
-  withoutcustomwidgetlambdaadminlistenerD7F971DF:
+  withoutcustomwidgetlambdaadminsharedlistener7B0C99C3:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withoutcustomwidgetlambdaadmintarget4DE7BC7C
+            Ref: withoutcustomwidgetlambdaadminsharedtargetA08818F7
           Type: forward
       LoadBalancerArn:
         Ref: withoutcustomwidgetlambdasharednlbB2365ABF
       Port: 9070
       Protocol: TCP
-  withoutcustomwidgetlambdanodelistener730AEEB8:
+  withoutcustomwidgetlambdanodesharedlistener49377192:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withoutcustomwidgetlambdanodetarget2D973BA7
+            Ref: withoutcustomwidgetlambdanodesharedtargetEA761A0C
           Type: forward
       LoadBalancerArn:
         Ref: withoutcustomwidgetlambdasharednlbB2365ABF
@@ -11510,15 +10010,15 @@ exports[`BYOC Without custom widget lambda 1`] = `
         - ContainerName: restate
           ContainerPort: 8080
           TargetGroupArn:
-            Ref: withoutcustomwidgetlambdaingresstarget4AD70E49
+            Ref: withoutcustomwidgetlambdaingresssharedtarget4513DA2B
         - ContainerName: restate
           ContainerPort: 9070
           TargetGroupArn:
-            Ref: withoutcustomwidgetlambdaadmintarget4DE7BC7C
+            Ref: withoutcustomwidgetlambdaadminsharedtargetA08818F7
         - ContainerName: restate
           ContainerPort: 5122
           TargetGroupArn:
-            Ref: withoutcustomwidgetlambdanodetarget2D973BA7
+            Ref: withoutcustomwidgetlambdanodesharedtargetEA761A0C
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
@@ -11537,9 +10037,9 @@ exports[`BYOC Without custom widget lambda 1`] = `
       TaskDefinition:
         Ref: withoutcustomwidgetlambdastatelessdefinition36FD513C
     DependsOn:
-      - withoutcustomwidgetlambdaadminlistenerD7F971DF
-      - withoutcustomwidgetlambdaingresslistener54C2C8B1
-      - withoutcustomwidgetlambdanodelistener730AEEB8
+      - withoutcustomwidgetlambdaadminsharedlistener7B0C99C3
+      - withoutcustomwidgetlambdaingresssharedlistener1C15A3B8
+      - withoutcustomwidgetlambdanodesharedlistener49377192
       - withoutcustomwidgetlambdarestatetaskroleDefaultPolicyF03DC3AE
       - withoutcustomwidgetlambdarestatetaskroleB95E12D3
   withoutcustomwidgetlambdastatefuldefinition0381E003:
@@ -11668,7 +10168,7 @@ exports[`BYOC Without custom widget lambda 1`] = `
           Value: RestateBYOC/without-custom-widget-lambda/stateful-definition
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
-  withoutcustomwidgetlambdaingresstarget4AD70E49:
+  withoutcustomwidgetlambdaingresssharedtarget4513DA2B:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -11680,11 +10180,11 @@ exports[`BYOC Without custom widget lambda 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/without-custom-widget-lambda/ingress-target
+          Value: RestateBYOC/without-custom-widget-lambda/ingress-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withoutcustomwidgetlambdaadmintarget4DE7BC7C:
+  withoutcustomwidgetlambdaadminsharedtargetA08818F7:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -11697,11 +10197,11 @@ exports[`BYOC Without custom widget lambda 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/without-custom-widget-lambda/admin-target
+          Value: RestateBYOC/without-custom-widget-lambda/admin-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withoutcustomwidgetlambdanodetarget2D973BA7:
+  withoutcustomwidgetlambdanodesharedtargetEA761A0C:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -11714,7 +10214,7 @@ exports[`BYOC Without custom widget lambda 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/without-custom-widget-lambda/node-target
+          Value: RestateBYOC/without-custom-widget-lambda/node-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
@@ -12775,6 +11275,81 @@ exports[`BYOC Without custom widget lambda 1`] = `
               target\\n          | sort @timestamp desc\\n          | limit
               500"}}]}
       DashboardName: RestateBYOC_without-custom-widget-lambda_metrics
+  withoutcustomwidgetlambdaservicedeployerlambdaexecutionroleEF56C011:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+  withoutcustomwidgetlambdaservicedeployerlambdaexecutionroleDefaultPolicy2F421E33:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+              - 'ec2:CreateNetworkInterface'
+              - 'ec2:DescribeNetworkInterfaces'
+              - 'ec2:DescribeSubnets'
+              - 'ec2:DeleteNetworkInterface'
+              - 'ec2:AssignPrivateIpAddresses'
+              - 'ec2:UnassignPrivateIpAddresses'
+            Effect: Allow
+            Resource: '*'
+            Sid: AWSLambdaVPCAccessExecutionPermissions
+        Version: '2012-10-17'
+      PolicyName: >-
+        withoutcustomwidgetlambdaservicedeployerlambdaexecutionroleDefaultPolicy2F421E33
+      Roles:
+        - Ref: withoutcustomwidgetlambdaservicedeployerlambdaexecutionroleEF56C011
+  withoutcustomwidgetlambdaservicedeployerEventHandler7DBAD3F6:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Architectures:
+        - arm64
+      Code: Any<Object>
+      Description: Restate custom registration handler
+      Environment:
+        Variables:
+          NODE_OPTIONS: '--enable-source-maps'
+      Handler: entrypoint.handler
+      MemorySize: 128
+      Role:
+        'Fn::GetAtt':
+          - withoutcustomwidgetlambdaservicedeployerlambdaexecutionroleEF56C011
+          - Arn
+      Runtime: nodejs22.x
+      Timeout: 180
+      VpcConfig:
+        SecurityGroupIds:
+          - 'Fn::GetAtt':
+              - withoutcustomwidgetlambdasecuritygroup059AA659
+              - GroupId
+        SubnetIds:
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
+    DependsOn:
+      - >-
+        withoutcustomwidgetlambdaservicedeployerlambdaexecutionroleDefaultPolicy2F421E33
+      - withoutcustomwidgetlambdaservicedeployerlambdaexecutionroleEF56C011
+  withoutcustomwidgetlambdaservicedeployerDeploymentLogsB7AC0067:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName:
+        'Fn::Join':
+          - ''
+          - - /aws/lambda/
+            - Ref: withoutcustomwidgetlambdaservicedeployerEventHandler7DBAD3F6
+      RetentionInDays: 30
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
 "
 `;
 
@@ -12980,34 +11555,34 @@ exports[`BYOC Without metrics dashboard 1`] = `
         - Key: Name
           Value: RestateBYOC/without-metrics-dashboard/shared-nlb
       Type: network
-  withoutmetricsdashboardingresslistener4CDF606E:
+  withoutmetricsdashboardingresssharedlistener7EA4B060:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withoutmetricsdashboardingresstarget4C9BEE99
+            Ref: withoutmetricsdashboardingresssharedtarget582A9DEB
           Type: forward
       LoadBalancerArn:
         Ref: withoutmetricsdashboardsharednlbA8403BAA
       Port: 8080
       Protocol: TCP
-  withoutmetricsdashboardadminlistener25450916:
+  withoutmetricsdashboardadminsharedlistener76E9B915:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withoutmetricsdashboardadmintarget046E8290
+            Ref: withoutmetricsdashboardadminsharedtarget330B6CB5
           Type: forward
       LoadBalancerArn:
         Ref: withoutmetricsdashboardsharednlbA8403BAA
       Port: 9070
       Protocol: TCP
-  withoutmetricsdashboardnodelistener08DE3E38:
+  withoutmetricsdashboardnodesharedlistener2C23C08C:
     Type: 'AWS::ElasticLoadBalancingV2::Listener'
     Properties:
       DefaultActions:
         - TargetGroupArn:
-            Ref: withoutmetricsdashboardnodetarget63751EF1
+            Ref: withoutmetricsdashboardnodesharedtarget841653BD
           Type: forward
       LoadBalancerArn:
         Ref: withoutmetricsdashboardsharednlbA8403BAA
@@ -13157,15 +11732,15 @@ exports[`BYOC Without metrics dashboard 1`] = `
         - ContainerName: restate
           ContainerPort: 8080
           TargetGroupArn:
-            Ref: withoutmetricsdashboardingresstarget4C9BEE99
+            Ref: withoutmetricsdashboardingresssharedtarget582A9DEB
         - ContainerName: restate
           ContainerPort: 9070
           TargetGroupArn:
-            Ref: withoutmetricsdashboardadmintarget046E8290
+            Ref: withoutmetricsdashboardadminsharedtarget330B6CB5
         - ContainerName: restate
           ContainerPort: 5122
           TargetGroupArn:
-            Ref: withoutmetricsdashboardnodetarget63751EF1
+            Ref: withoutmetricsdashboardnodesharedtarget841653BD
       NetworkConfiguration:
         AwsvpcConfiguration:
           AssignPublicIp: DISABLED
@@ -13184,9 +11759,9 @@ exports[`BYOC Without metrics dashboard 1`] = `
       TaskDefinition:
         Ref: withoutmetricsdashboardstatelessdefinition39D9FF8E
     DependsOn:
-      - withoutmetricsdashboardadminlistener25450916
-      - withoutmetricsdashboardingresslistener4CDF606E
-      - withoutmetricsdashboardnodelistener08DE3E38
+      - withoutmetricsdashboardadminsharedlistener76E9B915
+      - withoutmetricsdashboardingresssharedlistener7EA4B060
+      - withoutmetricsdashboardnodesharedlistener2C23C08C
       - withoutmetricsdashboardrestatetaskroleDefaultPolicy6A5DFCD8
       - withoutmetricsdashboardrestatetaskroleFB91830E
   withoutmetricsdashboardstatefuldefinition42DF14D8:
@@ -13315,7 +11890,7 @@ exports[`BYOC Without metrics dashboard 1`] = `
           Value: RestateBYOC/without-metrics-dashboard/stateful-definition
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
-  withoutmetricsdashboardingresstarget4C9BEE99:
+  withoutmetricsdashboardingresssharedtarget582A9DEB:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -13327,11 +11902,11 @@ exports[`BYOC Without metrics dashboard 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/without-metrics-dashboard/ingress-target
+          Value: RestateBYOC/without-metrics-dashboard/ingress-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withoutmetricsdashboardadmintarget046E8290:
+  withoutmetricsdashboardadminsharedtarget330B6CB5:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -13344,11 +11919,11 @@ exports[`BYOC Without metrics dashboard 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/without-metrics-dashboard/admin-target
+          Value: RestateBYOC/without-metrics-dashboard/admin-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
-  withoutmetricsdashboardnodetarget63751EF1:
+  withoutmetricsdashboardnodesharedtarget841653BD:
     Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
     Properties:
       HealthCheckEnabled: true
@@ -13361,7 +11936,7 @@ exports[`BYOC Without metrics dashboard 1`] = `
       Protocol: TCP
       Tags:
         - Key: Name
-          Value: RestateBYOC/without-metrics-dashboard/node-target
+          Value: RestateBYOC/without-metrics-dashboard/node-shared-target
       TargetType: ip
       VpcId:
         'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
@@ -14466,5 +13041,1917 @@ exports[`BYOC Without metrics dashboard 1`] = `
             - >-
               "}}}},"title":"","updateOn":{"refresh":true,"resize":true,"timeRange":true}}}]}
       DashboardName: RestateBYOC_without-metrics-dashboard_control-panel
+  withoutmetricsdashboardservicedeployerlambdaexecutionroleEB25789A:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+  withoutmetricsdashboardservicedeployerlambdaexecutionroleDefaultPolicy6D38CA6D:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+              - 'ec2:CreateNetworkInterface'
+              - 'ec2:DescribeNetworkInterfaces'
+              - 'ec2:DescribeSubnets'
+              - 'ec2:DeleteNetworkInterface'
+              - 'ec2:AssignPrivateIpAddresses'
+              - 'ec2:UnassignPrivateIpAddresses'
+            Effect: Allow
+            Resource: '*'
+            Sid: AWSLambdaVPCAccessExecutionPermissions
+        Version: '2012-10-17'
+      PolicyName: >-
+        withoutmetricsdashboardservicedeployerlambdaexecutionroleDefaultPolicy6D38CA6D
+      Roles:
+        - Ref: withoutmetricsdashboardservicedeployerlambdaexecutionroleEB25789A
+  withoutmetricsdashboardservicedeployerEventHandler739C15DE:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Architectures:
+        - arm64
+      Code: Any<Object>
+      Description: Restate custom registration handler
+      Environment:
+        Variables:
+          NODE_OPTIONS: '--enable-source-maps'
+      Handler: entrypoint.handler
+      MemorySize: 128
+      Role:
+        'Fn::GetAtt':
+          - withoutmetricsdashboardservicedeployerlambdaexecutionroleEB25789A
+          - Arn
+      Runtime: nodejs22.x
+      Timeout: 180
+      VpcConfig:
+        SecurityGroupIds:
+          - 'Fn::GetAtt':
+              - withoutmetricsdashboardsecuritygroup2805E007
+              - GroupId
+        SubnetIds:
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
+    DependsOn:
+      - >-
+        withoutmetricsdashboardservicedeployerlambdaexecutionroleDefaultPolicy6D38CA6D
+      - withoutmetricsdashboardservicedeployerlambdaexecutionroleEB25789A
+  withoutmetricsdashboardservicedeployerDeploymentLogs9FA363C0:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      LogGroupName:
+        'Fn::Join':
+          - ''
+          - - /aws/lambda/
+            - Ref: withoutmetricsdashboardservicedeployerEventHandler739C15DE
+      RetentionInDays: 30
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
 "
 `;
+
+exports[`BYOC Without service deployer 1`] = `
+"Resources:
+  withoutservicedeployersecuritygroup68EF3063:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: RestateBYOC/without-service-deployer/security-group
+      SecurityGroupEgress:
+        - CidrIp: 0.0.0.0/0
+          Description: Allow all outbound traffic by default
+          IpProtocol: '-1'
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/security-group
+      VpcId:
+        'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
+  withoutservicedeployersecuritygroupfromRestateBYOCwithoutservicedeployersecuritygroup97B1828F80808A0B9A20:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      Description: 'from RestateBYOCwithoutservicedeployersecuritygroup97B1828F:8080'
+      FromPort: 8080
+      GroupId:
+        'Fn::GetAtt':
+          - withoutservicedeployersecuritygroup68EF3063
+          - GroupId
+      IpProtocol: tcp
+      SourceSecurityGroupId:
+        'Fn::GetAtt':
+          - withoutservicedeployersecuritygroup68EF3063
+          - GroupId
+      ToPort: 8080
+  withoutservicedeployersecuritygroupfromRestateBYOCwithoutservicedeployersecuritygroup97B1828F90700E6175C1:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      Description: 'from RestateBYOCwithoutservicedeployersecuritygroup97B1828F:9070'
+      FromPort: 9070
+      GroupId:
+        'Fn::GetAtt':
+          - withoutservicedeployersecuritygroup68EF3063
+          - GroupId
+      IpProtocol: tcp
+      SourceSecurityGroupId:
+        'Fn::GetAtt':
+          - withoutservicedeployersecuritygroup68EF3063
+          - GroupId
+      ToPort: 9070
+  withoutservicedeployersecuritygroupfromRestateBYOCwithoutservicedeployersecuritygroup97B1828F512265C056CC:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    Properties:
+      Description: 'from RestateBYOCwithoutservicedeployersecuritygroup97B1828F:5122'
+      FromPort: 5122
+      GroupId:
+        'Fn::GetAtt':
+          - withoutservicedeployersecuritygroup68EF3063
+          - GroupId
+      IpProtocol: tcp
+      SourceSecurityGroupId:
+        'Fn::GetAtt':
+          - withoutservicedeployersecuritygroup68EF3063
+          - GroupId
+      ToPort: 5122
+  withoutservicedeployerbucketB1987DAB:
+    Type: 'AWS::S3::Bucket'
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+  withoutservicedeployerbucketPolicy95A5DE97:
+    Type: 'AWS::S3::BucketPolicy'
+    Properties:
+      Bucket:
+        Ref: withoutservicedeployerbucketB1987DAB
+      PolicyDocument:
+        Statement:
+          - Action: 's3:*'
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'false'
+            Effect: Deny
+            Principal:
+              AWS: '*'
+            Resource:
+              - 'Fn::GetAtt':
+                  - withoutservicedeployerbucketB1987DAB
+                  - Arn
+              - 'Fn::Join':
+                  - ''
+                  - - 'Fn::GetAtt':
+                        - withoutservicedeployerbucketB1987DAB
+                        - Arn
+                    - /*
+        Version: '2012-10-17'
+  withoutservicedeployerclusterC266C783:
+    Type: 'AWS::ECS::Cluster'
+    Properties:
+      ClusterSettings:
+        - Name: containerInsights
+          Value: enhanced
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/cluster
+  withoutservicedeployerrestatetaskrole0BA346B5:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: '2012-10-17'
+  withoutservicedeployerrestatetaskroleDefaultPolicy87F6ADA8:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 's3:GetObject'
+              - 's3:PutObject'
+            Effect: Allow
+            Resource:
+              'Fn::Join':
+                - ''
+                - - 'Fn::GetAtt':
+                      - withoutservicedeployerbucketB1987DAB
+                      - Arn
+                  - /*
+            Sid: ReadWriteBucket
+          - Action: 's3:ListBucket'
+            Effect: Allow
+            Resource:
+              'Fn::GetAtt':
+                - withoutservicedeployerbucketB1987DAB
+                - Arn
+            Sid: ListBucket
+        Version: '2012-10-17'
+      PolicyName: withoutservicedeployerrestatetaskroleDefaultPolicy87F6ADA8
+      Roles:
+        - Ref: withoutservicedeployerrestatetaskrole0BA346B5
+  withoutservicedeployerrestateexecutionroleC44D4A99:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: '2012-10-17'
+  withoutservicedeployerrestateexecutionroleDefaultPolicy90952A42:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+            Effect: Allow
+            Resource:
+              'Fn::GetAtt':
+                - >-
+                  withoutservicedeployerstatelessdefinitionrestateLogGroupEC27F989
+                - Arn
+          - Action:
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+            Effect: Allow
+            Resource:
+              'Fn::GetAtt':
+                - >-
+                  withoutservicedeployerstatefuldefinitionrestateLogGroupCE40C5FC
+                - Arn
+        Version: '2012-10-17'
+      PolicyName: withoutservicedeployerrestateexecutionroleDefaultPolicy90952A42
+      Roles:
+        - Ref: withoutservicedeployerrestateexecutionroleC44D4A99
+  withoutservicedeployersharednlb054F9DEE:
+    Type: 'AWS::ElasticLoadBalancingV2::LoadBalancer'
+    Properties:
+      LoadBalancerAttributes:
+        - Key: deletion_protection.enabled
+          Value: 'false'
+        - Key: load_balancing.cross_zone.enabled
+          Value: 'false'
+        - Key: dns_record.client_routing_policy
+          Value: availability_zone_affinity
+      Scheme: internal
+      SecurityGroups:
+        - 'Fn::GetAtt':
+            - withoutservicedeployersecuritygroup68EF3063
+            - GroupId
+      Subnets:
+        - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
+        - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
+        - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/shared-nlb
+      Type: network
+  withoutservicedeployeringresssharedlistener96F1E3C9:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      DefaultActions:
+        - TargetGroupArn:
+            Ref: withoutservicedeployeringresssharedtarget4F34F9D6
+          Type: forward
+      LoadBalancerArn:
+        Ref: withoutservicedeployersharednlb054F9DEE
+      Port: 8080
+      Protocol: TCP
+  withoutservicedeployeradminsharedlistener510F9C0E:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      DefaultActions:
+        - TargetGroupArn:
+            Ref: withoutservicedeployeradminsharedtarget5AEA9CF6
+          Type: forward
+      LoadBalancerArn:
+        Ref: withoutservicedeployersharednlb054F9DEE
+      Port: 9070
+      Protocol: TCP
+  withoutservicedeployernodesharedlistenerF82C2C12:
+    Type: 'AWS::ElasticLoadBalancingV2::Listener'
+    Properties:
+      DefaultActions:
+        - TargetGroupArn:
+            Ref: withoutservicedeployernodesharedtarget6F8051A0
+          Type: forward
+      LoadBalancerArn:
+        Ref: withoutservicedeployersharednlb054F9DEE
+      Port: 5122
+      Protocol: TCP
+  withoutservicedeployerstatelessdefinition8A66D938:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      ContainerDefinitions:
+        - Cpu: 16384
+          EntryPoint:
+            - bash
+            - '-c'
+            - >
+
+              curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4/task -o
+              task-metadata && \\
+
+              export \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Containers[0].Networks[0].IPv4Addresses[0]' task-metadata):5122"
+              exec restate-server
+          Environment:
+            - Name: RESTATE_LOG_FORMAT
+              Value: json
+            - Name: RESTATE_CLUSTER_NAME
+              Value: RestateBYOC/without-service-deployer
+            - Name: RESTATE_ROLES
+              Value: '["admin","http-ingress"]'
+            - Name: RESTATE_AUTO_PROVISION
+              Value: 'true'
+            - Name: RESTATE_SHUTDOWN_TIMEOUT
+              Value: 100s
+            - Name: RESTATE_DEFAULT_NUM_PARTITIONS
+              Value: '128'
+            - Name: RESTATE_DEFAULT_REPLICATION
+              Value: '{zone: 2}'
+            - Name: RESTATE_METADATA_CLIENT__TYPE
+              Value: object-store
+            - Name: RESTATE_METADATA_CLIENT__PATH
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - 's3://'
+                    - Ref: withoutservicedeployerbucketB1987DAB
+                    - /metadata
+            - Name: RESTATE_BIFROST__DEFAULT_PROVIDER
+              Value: replicated
+            - Name: >-
+                RESTATE_INGRESS__EXPERIMENTAL_FEATURE_ENABLE_SEPARATE_INGRESS_ROLE
+              Value: 'true'
+            - Name: RESTATE_INGRESS__ADVERTISED_INGRESS_ENDPOINT
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - 'http://'
+                    - 'Fn::GetAtt':
+                        - withoutservicedeployersharednlb054F9DEE
+                        - DNSName
+                    - ':8080'
+            - Name: RESTATE_WORKER__SNAPSHOTS__DESTINATION
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - 's3://'
+                    - Ref: withoutservicedeployerbucketB1987DAB
+                    - /snapshots
+          Essential: true
+          HealthCheck:
+            Command:
+              - CMD
+              - curl
+              - '--fail'
+              - 'http://127.0.0.1:8080/restate/health'
+            Interval: 30
+            Retries: 3
+            Timeout: 5
+          Image: Any<Object>
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group:
+                Ref: >-
+                  withoutservicedeployerstatelessdefinitionrestateLogGroupEC27F989
+              awslogs-stream-prefix: restate
+              awslogs-region: region
+          Memory: 32768
+          Name: restate
+          PortMappings:
+            - ContainerPort: 8080
+              Name: ingress
+              Protocol: tcp
+            - ContainerPort: 9070
+              Name: admin
+              Protocol: tcp
+            - ContainerPort: 5122
+              Name: node
+              Protocol: tcp
+          StopTimeout: 120
+      Cpu: '16384'
+      ExecutionRoleArn:
+        'Fn::GetAtt':
+          - withoutservicedeployerrestateexecutionroleC44D4A99
+          - Arn
+      Family: RestateBYOCwithoutservicedeployerstatelessdefinition466C1E01
+      Memory: '32768'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      RuntimePlatform:
+        CpuArchitecture: ARM64
+        OperatingSystemFamily: LINUX
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/stateless-definition
+      TaskRoleArn:
+        'Fn::GetAtt':
+          - withoutservicedeployerrestatetaskrole0BA346B5
+          - Arn
+  withoutservicedeployerstatelessdefinitionrestateLogGroupEC27F989:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/stateless-definition
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+  withoutservicedeployerstatelessserviceService4B925097:
+    Type: 'AWS::ECS::Service'
+    Properties:
+      Cluster:
+        Ref: withoutservicedeployerclusterC266C783
+      DeploymentConfiguration:
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: false
+        MaximumPercent: 200
+        MinimumHealthyPercent: 100
+      DesiredCount: 3
+      EnableECSManagedTags: false
+      EnableExecuteCommand: false
+      HealthCheckGracePeriodSeconds: 60
+      LaunchType: FARGATE
+      LoadBalancers:
+        - ContainerName: restate
+          ContainerPort: 8080
+          TargetGroupArn:
+            Ref: withoutservicedeployeringresssharedtarget4F34F9D6
+        - ContainerName: restate
+          ContainerPort: 9070
+          TargetGroupArn:
+            Ref: withoutservicedeployeradminsharedtarget5AEA9CF6
+        - ContainerName: restate
+          ContainerPort: 5122
+          TargetGroupArn:
+            Ref: withoutservicedeployernodesharedtarget6F8051A0
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          SecurityGroups:
+            - 'Fn::GetAtt':
+                - withoutservicedeployersecuritygroup68EF3063
+                - GroupId
+          Subnets:
+            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
+            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
+            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
+      PropagateTags: SERVICE
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/stateless-service
+      TaskDefinition:
+        Ref: withoutservicedeployerstatelessdefinition8A66D938
+    DependsOn:
+      - withoutservicedeployeradminsharedlistener510F9C0E
+      - withoutservicedeployeringresssharedlistener96F1E3C9
+      - withoutservicedeployernodesharedlistenerF82C2C12
+      - withoutservicedeployerrestatetaskroleDefaultPolicy87F6ADA8
+      - withoutservicedeployerrestatetaskrole0BA346B5
+  withoutservicedeployerstatefuldefinition9743572A:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      ContainerDefinitions:
+        - Cpu: 16384
+          EntryPoint:
+            - bash
+            - '-c'
+            - >
+
+              curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4/task -o
+              task-metadata && \\
+
+              export \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Containers[0].Networks[0].IPv4Addresses[0]' task-metadata):5122"
+              exec restate-server
+          Environment:
+            - Name: RESTATE_LOG_FORMAT
+              Value: json
+            - Name: RESTATE_CLUSTER_NAME
+              Value: RestateBYOC/without-service-deployer
+            - Name: RESTATE_ROLES
+              Value: '["log-server", "worker"]'
+            - Name: RESTATE_AUTO_PROVISION
+              Value: 'false'
+            - Name: RESTATE_SHUTDOWN_TIMEOUT
+              Value: 100s
+            - Name: RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE
+              Value: 24576MiB
+            - Name: RESTATE_METADATA_CLIENT__TYPE
+              Value: object-store
+            - Name: RESTATE_METADATA_CLIENT__PATH
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - 's3://'
+                    - Ref: withoutservicedeployerbucketB1987DAB
+                    - /metadata
+            - Name: RESTATE_WORKER__SNAPSHOTS__DESTINATION
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - 's3://'
+                    - Ref: withoutservicedeployerbucketB1987DAB
+                    - /snapshots
+            - Name: RESTATE_WORKER__SNAPSHOTS__SNAPSHOT_INTERVAL_NUM_RECORDS
+              Value: '1000000'
+            - Name: RESTATE_WORKER__STORAGE__ROCKSDB_DISABLE_DIRECT_IO_FOR_READS
+              Value: 'true'
+            - Name: RESTATE_WORKER__STORAGE__ROCKSDB_DISABLE_WAL_FSYNC
+              Value: 'true'
+            - Name: RESTATE_LOG_SERVER__ROCKSDB_DISABLE_WAL_FSYNC
+              Value: 'true'
+            - Name: RESTATE_LOG_SERVER__ROCKSDB_DISABLE_DIRECT_IO_FOR_READS
+              Value: 'true'
+            - Name: >-
+                RESTATE_INGRESS__EXPERIMENTAL_FEATURE_ENABLE_SEPARATE_INGRESS_ROLE
+              Value: 'true'
+          Essential: true
+          HealthCheck:
+            Command:
+              - CMD
+              - curl
+              - '--fail'
+              - 'http://127.0.0.1:5122/health'
+            Interval: 30
+            Retries: 3
+            Timeout: 5
+          Image: Any<Object>
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group:
+                Ref: >-
+                  withoutservicedeployerstatefuldefinitionrestateLogGroupCE40C5FC
+              awslogs-stream-prefix: restate
+              awslogs-region: region
+          Memory: 32768
+          MountPoints:
+            - ContainerPath: /restate-data
+              ReadOnly: false
+              SourceVolume: restate-data
+          Name: restate
+          PortMappings:
+            - ContainerPort: 5122
+              Name: node
+              Protocol: tcp
+          RestartPolicy:
+            Enabled: true
+            RestartAttemptPeriod: 60
+          StopTimeout: 120
+      Cpu: '16384'
+      EphemeralStorage:
+        SizeInGiB: 200
+      ExecutionRoleArn:
+        'Fn::GetAtt':
+          - withoutservicedeployerrestateexecutionroleC44D4A99
+          - Arn
+      Family: RestateBYOCwithoutservicedeployerstatefuldefinition55E65D66
+      Memory: '32768'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      RuntimePlatform:
+        CpuArchitecture: ARM64
+        OperatingSystemFamily: LINUX
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/stateful-definition
+      TaskRoleArn:
+        'Fn::GetAtt':
+          - withoutservicedeployerrestatetaskrole0BA346B5
+          - Arn
+      Volumes:
+        - ConfiguredAtLaunch: false
+          Name: restate-data
+  withoutservicedeployerstatefuldefinitionrestateLogGroupCE40C5FC:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/stateful-definition
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+  withoutservicedeployeringresssharedtarget4F34F9D6:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Properties:
+      HealthCheckEnabled: true
+      HealthCheckIntervalSeconds: 5
+      HealthCheckPath: /restate/health
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 2
+      Port: 8080
+      Protocol: TCP
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/ingress-shared-target
+      TargetType: ip
+      VpcId:
+        'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
+  withoutservicedeployeradminsharedtarget5AEA9CF6:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Properties:
+      HealthCheckEnabled: true
+      HealthCheckIntervalSeconds: 5
+      HealthCheckPath: /health
+      HealthCheckPort: '9070'
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 2
+      Port: 9070
+      Protocol: TCP
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/admin-shared-target
+      TargetType: ip
+      VpcId:
+        'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
+  withoutservicedeployernodesharedtarget6F8051A0:
+    Type: 'AWS::ElasticLoadBalancingV2::TargetGroup'
+    Properties:
+      HealthCheckEnabled: true
+      HealthCheckIntervalSeconds: 5
+      HealthCheckPath: /health
+      HealthCheckPort: '5122'
+      HealthCheckProtocol: HTTP
+      HealthCheckTimeoutSeconds: 2
+      Port: 5122
+      Protocol: TCP
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/node-shared-target
+      TargetType: ip
+      VpcId:
+        'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
+  withoutservicedeployercontrollertaskrole618DDFFF:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: '2012-10-17'
+  withoutservicedeployercontrollertaskroleDefaultPolicy23DA16F5:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'ecs:ListTasks'
+              - 'ecs:DescribeTasks'
+              - 'ecs:StopTask'
+            Condition:
+              ArnEquals:
+                'ecs:cluster':
+                  'Fn::GetAtt':
+                    - withoutservicedeployerclusterC266C783
+                    - Arn
+            Effect: Allow
+            Resource: '*'
+            Sid: TaskActions
+          - Action: 'ecs:TagResource'
+            Effect: Allow
+            Resource:
+              'Fn::Join':
+                - ''
+                - - 'Fn::Join':
+                      - /
+                      - - 'Fn::Join':
+                            - ':'
+                            - - 'Fn::Select':
+                                  - 0
+                                  - 'Fn::Split':
+                                      - ':'
+                                      - 'Fn::Select':
+                                          - 0
+                                          - 'Fn::Split':
+                                              - /
+                                              - 'Fn::GetAtt':
+                                                  - withoutservicedeployerclusterC266C783
+                                                  - Arn
+                              - 'Fn::Select':
+                                  - 1
+                                  - 'Fn::Split':
+                                      - ':'
+                                      - 'Fn::Select':
+                                          - 0
+                                          - 'Fn::Split':
+                                              - /
+                                              - 'Fn::GetAtt':
+                                                  - withoutservicedeployerclusterC266C783
+                                                  - Arn
+                              - 'Fn::Select':
+                                  - 2
+                                  - 'Fn::Split':
+                                      - ':'
+                                      - 'Fn::Select':
+                                          - 0
+                                          - 'Fn::Split':
+                                              - /
+                                              - 'Fn::GetAtt':
+                                                  - withoutservicedeployerclusterC266C783
+                                                  - Arn
+                              - 'Fn::Select':
+                                  - 3
+                                  - 'Fn::Split':
+                                      - ':'
+                                      - 'Fn::Select':
+                                          - 0
+                                          - 'Fn::Split':
+                                              - /
+                                              - 'Fn::GetAtt':
+                                                  - withoutservicedeployerclusterC266C783
+                                                  - Arn
+                              - 'Fn::Select':
+                                  - 4
+                                  - 'Fn::Split':
+                                      - ':'
+                                      - 'Fn::Select':
+                                          - 0
+                                          - 'Fn::Split':
+                                              - /
+                                              - 'Fn::GetAtt':
+                                                  - withoutservicedeployerclusterC266C783
+                                                  - Arn
+                              - task
+                        - 'Fn::Select':
+                            - 1
+                            - 'Fn::Split':
+                                - /
+                                - 'Fn::GetAtt':
+                                    - withoutservicedeployerclusterC266C783
+                                    - Arn
+                        - ''
+                  - '*'
+            Sid: TagTasks
+          - Action: 'ecs:RunTask'
+            Condition:
+              ArnEquals:
+                'ecs:cluster':
+                  'Fn::GetAtt':
+                    - withoutservicedeployerclusterC266C783
+                    - Arn
+            Effect: Allow
+            Resource:
+              'Fn::Join':
+                - ''
+                - - 'Fn::Join':
+                      - ':'
+                      - - 'Fn::Select':
+                            - 0
+                            - 'Fn::Split':
+                                - ':'
+                                - Ref: >-
+                                    withoutservicedeployerstatefuldefinition9743572A
+                        - 'Fn::Select':
+                            - 1
+                            - 'Fn::Split':
+                                - ':'
+                                - Ref: >-
+                                    withoutservicedeployerstatefuldefinition9743572A
+                        - 'Fn::Select':
+                            - 2
+                            - 'Fn::Split':
+                                - ':'
+                                - Ref: >-
+                                    withoutservicedeployerstatefuldefinition9743572A
+                        - 'Fn::Select':
+                            - 3
+                            - 'Fn::Split':
+                                - ':'
+                                - Ref: >-
+                                    withoutservicedeployerstatefuldefinition9743572A
+                        - 'Fn::Select':
+                            - 4
+                            - 'Fn::Split':
+                                - ':'
+                                - Ref: >-
+                                    withoutservicedeployerstatefuldefinition9743572A
+                        - 'Fn::Select':
+                            - 5
+                            - 'Fn::Split':
+                                - ':'
+                                - Ref: >-
+                                    withoutservicedeployerstatefuldefinition9743572A
+                  - ':*'
+            Sid: RunTask
+          - Action: 'iam:PassRole'
+            Condition:
+              StringEquals:
+                'iam:PassedToService': ecs-tasks.amazonaws.com
+            Effect: Allow
+            Resource:
+              - 'Fn::GetAtt':
+                  - withoutservicedeployerrestatetaskrole0BA346B5
+                  - Arn
+              - 'Fn::GetAtt':
+                  - withoutservicedeployerrestateexecutionroleC44D4A99
+                  - Arn
+            Sid: RunTaskPassRole
+          - Action:
+              - 's3:GetObject'
+              - 's3:PutObject'
+            Effect: Allow
+            Resource:
+              'Fn::Join':
+                - ''
+                - - 'Fn::GetAtt':
+                      - withoutservicedeployerbucketB1987DAB
+                      - Arn
+                  - /*
+            Sid: ReadWriteBucket
+          - Action: 's3:ListBucket'
+            Effect: Allow
+            Resource:
+              'Fn::GetAtt':
+                - withoutservicedeployerbucketB1987DAB
+                - Arn
+            Sid: ListBucket
+        Version: '2012-10-17'
+      PolicyName: withoutservicedeployercontrollertaskroleDefaultPolicy23DA16F5
+      Roles:
+        - Ref: withoutservicedeployercontrollertaskrole618DDFFF
+  withoutservicedeployercontrollerexecutionroleEED6FF08:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: ecs-tasks.amazonaws.com
+        Version: '2012-10-17'
+  withoutservicedeployercontrollerexecutionroleDefaultPolicyB2F6A3F9:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+            Effect: Allow
+            Resource:
+              'Fn::GetAtt':
+                - >-
+                  withoutservicedeployercontrollerdefinitioncontrollerLogGroupC38FCA92
+                - Arn
+        Version: '2012-10-17'
+      PolicyName: withoutservicedeployercontrollerexecutionroleDefaultPolicyB2F6A3F9
+      Roles:
+        - Ref: withoutservicedeployercontrollerexecutionroleEED6FF08
+  withoutservicedeployercontrollerdefinition0FA6B55C:
+    Type: 'AWS::ECS::TaskDefinition'
+    Properties:
+      ContainerDefinitions:
+        - Cpu: 1024
+          Environment:
+            - Name: RUST_LOG
+              Value: 'info,restate_fargate_controller=debug'
+            - Name: CONTROLLER_LOG_FORMAT
+              Value: json
+            - Name: CONTROLLER_METADATA_PATH
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - 's3://'
+                    - Ref: withoutservicedeployerbucketB1987DAB
+                    - /metadata
+            - Name: CONTROLLER_RECONCILE_INTERVAL
+              Value: 10s
+            - Name: CONTROLLER_CLUSTER__CLUSTER_ARN
+              Value:
+                'Fn::GetAtt':
+                  - withoutservicedeployerclusterC266C783
+                  - Arn
+            - Name: CONTROLLER_LICENSE_ID
+              Value: foo
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __REGION
+              Value:
+                Ref: 'AWS::Region'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __CLUSTER_ARN
+              Value:
+                'Fn::GetAtt':
+                  - withoutservicedeployerclusterC266C783
+                  - Arn
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __TASK_PREFIX
+              Value:
+                'Fn::Join':
+                  - /
+                  - - 'Fn::Join':
+                        - ':'
+                        - - 'Fn::Select':
+                              - 0
+                              - 'Fn::Split':
+                                  - ':'
+                                  - 'Fn::Select':
+                                      - 0
+                                      - 'Fn::Split':
+                                          - /
+                                          - 'Fn::GetAtt':
+                                              - withoutservicedeployerclusterC266C783
+                                              - Arn
+                          - 'Fn::Select':
+                              - 1
+                              - 'Fn::Split':
+                                  - ':'
+                                  - 'Fn::Select':
+                                      - 0
+                                      - 'Fn::Split':
+                                          - /
+                                          - 'Fn::GetAtt':
+                                              - withoutservicedeployerclusterC266C783
+                                              - Arn
+                          - 'Fn::Select':
+                              - 2
+                              - 'Fn::Split':
+                                  - ':'
+                                  - 'Fn::Select':
+                                      - 0
+                                      - 'Fn::Split':
+                                          - /
+                                          - 'Fn::GetAtt':
+                                              - withoutservicedeployerclusterC266C783
+                                              - Arn
+                          - 'Fn::Select':
+                              - 3
+                              - 'Fn::Split':
+                                  - ':'
+                                  - 'Fn::Select':
+                                      - 0
+                                      - 'Fn::Split':
+                                          - /
+                                          - 'Fn::GetAtt':
+                                              - withoutservicedeployerclusterC266C783
+                                              - Arn
+                          - 'Fn::Select':
+                              - 4
+                              - 'Fn::Split':
+                                  - ':'
+                                  - 'Fn::Select':
+                                      - 0
+                                      - 'Fn::Split':
+                                          - /
+                                          - 'Fn::GetAtt':
+                                              - withoutservicedeployerclusterC266C783
+                                              - Arn
+                          - task
+                    - 'Fn::Select':
+                        - 1
+                        - 'Fn::Split':
+                            - /
+                            - 'Fn::GetAtt':
+                                - withoutservicedeployerclusterC266C783
+                                - Arn
+                    - ''
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1a__ENABLE_EXECUTE_COMMAND
+              Value: 'false'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1a__SECURITY_GROUPS
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - '["'
+                    - 'Fn::GetAtt':
+                        - withoutservicedeployersecuritygroup68EF3063
+                        - GroupId
+                    - '"]'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1a__SUBNETS
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - '["'
+                    - 'Fn::ImportValue': >-
+                        VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271
+                    - '"]'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1a__TASK_DEFINITION_ARN
+              Value:
+                Ref: withoutservicedeployerstatefuldefinition9743572A
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1a__COUNT
+              Value: '1'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1b__ENABLE_EXECUTE_COMMAND
+              Value: 'false'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1b__SECURITY_GROUPS
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - '["'
+                    - 'Fn::GetAtt':
+                        - withoutservicedeployersecuritygroup68EF3063
+                        - GroupId
+                    - '"]'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1b__SUBNETS
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - '["'
+                    - 'Fn::ImportValue': >-
+                        VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE
+                    - '"]'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1b__TASK_DEFINITION_ARN
+              Value:
+                Ref: withoutservicedeployerstatefuldefinition9743572A
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1b__COUNT
+              Value: '1'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1c__ENABLE_EXECUTE_COMMAND
+              Value: 'false'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1c__SECURITY_GROUPS
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - '["'
+                    - 'Fn::GetAtt':
+                        - withoutservicedeployersecuritygroup68EF3063
+                        - GroupId
+                    - '"]'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1c__SUBNETS
+              Value:
+                'Fn::Join':
+                  - ''
+                  - - '["'
+                    - 'Fn::ImportValue': >-
+                        VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491
+                    - '"]'
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1c__TASK_DEFINITION_ARN
+              Value:
+                Ref: withoutservicedeployerstatefuldefinition9743572A
+            - Name:
+                'Fn::Join':
+                  - ''
+                  - - CONTROLLER_ECS_CLUSTERS__
+                    - Ref: 'AWS::Region'
+                    - __ZONES__dummy1c__COUNT
+              Value: '1'
+          Essential: true
+          HealthCheck:
+            Command:
+              - CMD
+              - curl
+              - '--fail'
+              - 'http://127.0.0.1:8080/health'
+            Interval: 30
+            Retries: 10
+            StartPeriod: 300
+            Timeout: 5
+          Image: Any<Object>
+          LogConfiguration:
+            LogDriver: awslogs
+            Options:
+              awslogs-group:
+                Ref: >-
+                  withoutservicedeployercontrollerdefinitioncontrollerLogGroupC38FCA92
+              awslogs-stream-prefix: controller
+              awslogs-region: region
+          Memory: 2048
+          Name: controller
+          StopTimeout: 120
+      Cpu: '1024'
+      ExecutionRoleArn:
+        'Fn::GetAtt':
+          - withoutservicedeployercontrollerexecutionroleEED6FF08
+          - Arn
+      Family: RestateBYOCwithoutservicedeployercontrollerdefinitionFE9E7EDD
+      Memory: '2048'
+      NetworkMode: awsvpc
+      RequiresCompatibilities:
+        - FARGATE
+      RuntimePlatform:
+        CpuArchitecture: ARM64
+        OperatingSystemFamily: LINUX
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/controller-definition
+      TaskRoleArn:
+        'Fn::GetAtt':
+          - withoutservicedeployercontrollertaskrole618DDFFF
+          - Arn
+  withoutservicedeployercontrollerdefinitioncontrollerLogGroupC38FCA92:
+    Type: 'AWS::Logs::LogGroup'
+    Properties:
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/controller-definition
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+  withoutservicedeployercontrollerserviceService53E53874:
+    Type: 'AWS::ECS::Service'
+    Properties:
+      Cluster:
+        Ref: withoutservicedeployerclusterC266C783
+      DeploymentConfiguration:
+        Alarms:
+          AlarmNames: []
+          Enable: false
+          Rollback: false
+        MaximumPercent: 100
+        MinimumHealthyPercent: 0
+      DesiredCount: 1
+      EnableECSManagedTags: false
+      EnableExecuteCommand: false
+      LaunchType: FARGATE
+      NetworkConfiguration:
+        AwsvpcConfiguration:
+          AssignPublicIp: DISABLED
+          SecurityGroups:
+            - 'Fn::GetAtt':
+                - withoutservicedeployersecuritygroup68EF3063
+                - GroupId
+          Subnets:
+            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
+            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
+            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/controller-service
+      TaskDefinition:
+        Ref: withoutservicedeployercontrollerdefinition0FA6B55C
+    DependsOn:
+      - withoutservicedeployercontrollertaskroleDefaultPolicy23DA16F5
+      - withoutservicedeployercontrollertaskrole618DDFFF
+  withoutservicedeployerrestatectllambdaexecutionrole17BB387E:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+  withoutservicedeployerrestatectllambdaexecutionroleDefaultPolicy3BEF6BA1:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+              - 'ec2:CreateNetworkInterface'
+              - 'ec2:DescribeNetworkInterfaces'
+              - 'ec2:DescribeSubnets'
+              - 'ec2:DeleteNetworkInterface'
+              - 'ec2:AssignPrivateIpAddresses'
+              - 'ec2:UnassignPrivateIpAddresses'
+            Effect: Allow
+            Resource: '*'
+            Sid: AWSLambdaVPCAccessExecutionPermissions
+        Version: '2012-10-17'
+      PolicyName: withoutservicedeployerrestatectllambdaexecutionroleDefaultPolicy3BEF6BA1
+      Roles:
+        - Ref: withoutservicedeployerrestatectllambdaexecutionrole17BB387E
+  withoutservicedeployerrestatectllambda9B5C28C5:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Architectures:
+        - arm64
+      Code: Any<Object>
+      Environment:
+        Variables:
+          RESTATECTL_ADDRESS:
+            'Fn::Join':
+              - ''
+              - - 'http://'
+                - 'Fn::GetAtt':
+                    - withoutservicedeployersharednlb054F9DEE
+                    - DNSName
+                - ':5122'
+      Handler: restatectl
+      Role:
+        'Fn::GetAtt':
+          - withoutservicedeployerrestatectllambdaexecutionrole17BB387E
+          - Arn
+      Runtime: provided.al2023
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/restatectl-lambda
+      Timeout: 10
+      VpcConfig:
+        SecurityGroupIds:
+          - 'Fn::GetAtt':
+              - withoutservicedeployersecuritygroup68EF3063
+              - GroupId
+        SubnetIds:
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
+          - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
+    DependsOn:
+      - withoutservicedeployerrestatectllambdaexecutionroleDefaultPolicy3BEF6BA1
+      - withoutservicedeployerrestatectllambdaexecutionrole17BB387E
+  withoutservicedeployerretirementwatcherlambdaexecutionrole1D0DEF51:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+  withoutservicedeployerretirementwatcherlambdaexecutionroleDefaultPolicyBC949A2F:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+            Effect: Allow
+            Resource: '*'
+            Sid: AWSLambdaBasicExecutionPermissions
+          - Action: 'ecs:TagResource'
+            Effect: Allow
+            Resource:
+              'Fn::Join':
+                - ''
+                - - 'Fn::Join':
+                      - /
+                      - - 'Fn::Join':
+                            - ':'
+                            - - 'Fn::Select':
+                                  - 0
+                                  - 'Fn::Split':
+                                      - ':'
+                                      - 'Fn::Select':
+                                          - 0
+                                          - 'Fn::Split':
+                                              - /
+                                              - 'Fn::GetAtt':
+                                                  - withoutservicedeployerclusterC266C783
+                                                  - Arn
+                              - 'Fn::Select':
+                                  - 1
+                                  - 'Fn::Split':
+                                      - ':'
+                                      - 'Fn::Select':
+                                          - 0
+                                          - 'Fn::Split':
+                                              - /
+                                              - 'Fn::GetAtt':
+                                                  - withoutservicedeployerclusterC266C783
+                                                  - Arn
+                              - 'Fn::Select':
+                                  - 2
+                                  - 'Fn::Split':
+                                      - ':'
+                                      - 'Fn::Select':
+                                          - 0
+                                          - 'Fn::Split':
+                                              - /
+                                              - 'Fn::GetAtt':
+                                                  - withoutservicedeployerclusterC266C783
+                                                  - Arn
+                              - 'Fn::Select':
+                                  - 3
+                                  - 'Fn::Split':
+                                      - ':'
+                                      - 'Fn::Select':
+                                          - 0
+                                          - 'Fn::Split':
+                                              - /
+                                              - 'Fn::GetAtt':
+                                                  - withoutservicedeployerclusterC266C783
+                                                  - Arn
+                              - 'Fn::Select':
+                                  - 4
+                                  - 'Fn::Split':
+                                      - ':'
+                                      - 'Fn::Select':
+                                          - 0
+                                          - 'Fn::Split':
+                                              - /
+                                              - 'Fn::GetAtt':
+                                                  - withoutservicedeployerclusterC266C783
+                                                  - Arn
+                              - task
+                        - 'Fn::Select':
+                            - 1
+                            - 'Fn::Split':
+                                - /
+                                - 'Fn::GetAtt':
+                                    - withoutservicedeployerclusterC266C783
+                                    - Arn
+                        - ''
+                  - '*'
+            Sid: TagTasks
+          - Action:
+              - 'sqs:ReceiveMessage'
+              - 'sqs:ChangeMessageVisibility'
+              - 'sqs:GetQueueUrl'
+              - 'sqs:DeleteMessage'
+              - 'sqs:GetQueueAttributes'
+            Effect: Allow
+            Resource:
+              'Fn::GetAtt':
+                - withoutservicedeployerretirementwatcherqueue22A5702A
+                - Arn
+        Version: '2012-10-17'
+      PolicyName: >-
+        withoutservicedeployerretirementwatcherlambdaexecutionroleDefaultPolicyBC949A2F
+      Roles:
+        - Ref: withoutservicedeployerretirementwatcherlambdaexecutionrole1D0DEF51
+  withoutservicedeployerretirementwatcherlambdaA642DDE8:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Architectures:
+        - arm64
+      Code: Any<Object>
+      Handler: index.handler
+      Role:
+        'Fn::GetAtt':
+          - withoutservicedeployerretirementwatcherlambdaexecutionrole1D0DEF51
+          - Arn
+      Runtime: nodejs22.x
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/retirement-watcher-lambda
+      Timeout: 60
+    DependsOn:
+      - >-
+        withoutservicedeployerretirementwatcherlambdaexecutionroleDefaultPolicyBC949A2F
+      - withoutservicedeployerretirementwatcherlambdaexecutionrole1D0DEF51
+  withoutservicedeployerretirementwatcherlambdaSqsEventSourceRestateBYOCwithoutservicedeployerretirementwatcherqueue4D9552904A54187C:
+    Type: 'AWS::Lambda::EventSourceMapping'
+    Properties:
+      BatchSize: 1
+      EventSourceArn:
+        'Fn::GetAtt':
+          - withoutservicedeployerretirementwatcherqueue22A5702A
+          - Arn
+      FunctionName:
+        Ref: withoutservicedeployerretirementwatcherlambdaA642DDE8
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/retirement-watcher-lambda
+  withoutservicedeployerretirementwatcherqueue22A5702A:
+    Type: 'AWS::SQS::Queue'
+    Properties:
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/retirement-watcher-queue
+      VisibilityTimeout: 60
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+  withoutservicedeployerretirementwatcherqueuePolicy82BEDBF6:
+    Type: 'AWS::SQS::QueuePolicy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'sqs:SendMessage'
+              - 'sqs:GetQueueAttributes'
+              - 'sqs:GetQueueUrl'
+            Condition:
+              ArnEquals:
+                'aws:SourceArn':
+                  'Fn::GetAtt':
+                    - withoutservicedeployerretirementwatcherruleDFB1BB47
+                    - Arn
+            Effect: Allow
+            Principal:
+              Service: events.amazonaws.com
+            Resource:
+              'Fn::GetAtt':
+                - withoutservicedeployerretirementwatcherqueue22A5702A
+                - Arn
+        Version: '2012-10-17'
+      Queues:
+        - Ref: withoutservicedeployerretirementwatcherqueue22A5702A
+  withoutservicedeployerretirementwatcherruleDFB1BB47:
+    Type: 'AWS::Events::Rule'
+    Properties:
+      EventPattern:
+        detail:
+          eventTypeCode:
+            - equals-ignore-case: AWS_ECS_TASK_PATCHING_RETIREMENT
+          service:
+            - equals-ignore-case: ecs
+        resources:
+          - prefix:
+              'Fn::Join':
+                - /
+                - - 'Fn::Join':
+                      - ':'
+                      - - 'Fn::Select':
+                            - 0
+                            - 'Fn::Split':
+                                - ':'
+                                - 'Fn::Select':
+                                    - 0
+                                    - 'Fn::Split':
+                                        - /
+                                        - 'Fn::GetAtt':
+                                            - withoutservicedeployerclusterC266C783
+                                            - Arn
+                        - 'Fn::Select':
+                            - 1
+                            - 'Fn::Split':
+                                - ':'
+                                - 'Fn::Select':
+                                    - 0
+                                    - 'Fn::Split':
+                                        - /
+                                        - 'Fn::GetAtt':
+                                            - withoutservicedeployerclusterC266C783
+                                            - Arn
+                        - 'Fn::Select':
+                            - 2
+                            - 'Fn::Split':
+                                - ':'
+                                - 'Fn::Select':
+                                    - 0
+                                    - 'Fn::Split':
+                                        - /
+                                        - 'Fn::GetAtt':
+                                            - withoutservicedeployerclusterC266C783
+                                            - Arn
+                        - 'Fn::Select':
+                            - 3
+                            - 'Fn::Split':
+                                - ':'
+                                - 'Fn::Select':
+                                    - 0
+                                    - 'Fn::Split':
+                                        - /
+                                        - 'Fn::GetAtt':
+                                            - withoutservicedeployerclusterC266C783
+                                            - Arn
+                        - 'Fn::Select':
+                            - 4
+                            - 'Fn::Split':
+                                - ':'
+                                - 'Fn::Select':
+                                    - 0
+                                    - 'Fn::Split':
+                                        - /
+                                        - 'Fn::GetAtt':
+                                            - withoutservicedeployerclusterC266C783
+                                            - Arn
+                        - task
+                  - 'Fn::Select':
+                      - 1
+                      - 'Fn::Split':
+                          - /
+                          - 'Fn::GetAtt':
+                              - withoutservicedeployerclusterC266C783
+                              - Arn
+                  - ''
+        detail-type:
+          - equals-ignore-case: AWS Health Event
+      State: ENABLED
+      Targets:
+        - Arn:
+            'Fn::GetAtt':
+              - withoutservicedeployerretirementwatcherqueue22A5702A
+              - Arn
+          Id: Target0
+  withoutservicedeployercloudwatchcustomwidgetexecutionrole63498CC5:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: 'sts:AssumeRole'
+            Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+        Version: '2012-10-17'
+  withoutservicedeployercloudwatchcustomwidgetexecutionroleDefaultPolicyB278087E:
+    Type: 'AWS::IAM::Policy'
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Action:
+              - 'logs:CreateLogGroup'
+              - 'logs:CreateLogStream'
+              - 'logs:PutLogEvents'
+            Effect: Allow
+            Resource: '*'
+            Sid: AWSLambdaBasicExecutionPermissions
+          - Action: 'lambda:InvokeFunction'
+            Effect: Allow
+            Resource:
+              'Fn::GetAtt':
+                - withoutservicedeployerrestatectllambda9B5C28C5
+                - Arn
+            Sid: InvokeRestatectl
+          - Action:
+              - 'ec2:DescribeVolumes'
+              - 'ec2:DescribeVolumeStatus'
+            Effect: Allow
+            Resource: '*'
+            Sid: EC2ReadActions
+          - Action: 'ecs:DescribeTaskDefinition'
+            Effect: Allow
+            Resource: '*'
+            Sid: ECSReadActions
+          - Action: 'ecs:ListTasks'
+            Condition:
+              StringEquals:
+                'ecs:cluster':
+                  'Fn::GetAtt':
+                    - withoutservicedeployerclusterC266C783
+                    - Arn
+            Effect: Allow
+            Resource: '*'
+            Sid: ECSListTasks
+          - Action: 'ecs:DescribeTasks'
+            Condition:
+              StringEquals:
+                'ecs:cluster':
+                  'Fn::GetAtt':
+                    - withoutservicedeployerclusterC266C783
+                    - Arn
+            Effect: Allow
+            Resource:
+              'Fn::Join':
+                - ''
+                - - 'arn:'
+                  - Ref: 'AWS::Partition'
+                  - ':ecs:'
+                  - Ref: 'AWS::Region'
+                  - ':'
+                  - Ref: 'AWS::AccountId'
+                  - ':task/'
+                  - Ref: withoutservicedeployerclusterC266C783
+                  - /*
+            Sid: ECSDescribeTasks
+          - Action: 'ecs:DescribeServices'
+            Condition:
+              StringEquals:
+                'ecs:cluster':
+                  'Fn::GetAtt':
+                    - withoutservicedeployerclusterC266C783
+                    - Arn
+            Effect: Allow
+            Resource:
+              'Fn::Join':
+                - ''
+                - - 'arn:'
+                  - Ref: 'AWS::Partition'
+                  - ':ecs:'
+                  - Ref: 'AWS::Region'
+                  - ':'
+                  - Ref: 'AWS::AccountId'
+                  - ':service/'
+                  - Ref: withoutservicedeployerclusterC266C783
+                  - /*
+            Sid: ECSDescribeServices
+          - Action: 'cloudwatch:GetMetricData'
+            Effect: Allow
+            Resource: '*'
+            Sid: CloudWatchReadActions
+        Version: '2012-10-17'
+      PolicyName: >-
+        withoutservicedeployercloudwatchcustomwidgetexecutionroleDefaultPolicyB278087E
+      Roles:
+        - Ref: withoutservicedeployercloudwatchcustomwidgetexecutionrole63498CC5
+  withoutservicedeployercloudwatchcustomwidgetlambda09DF3572:
+    Type: 'AWS::Lambda::Function'
+    Properties:
+      Architectures:
+        - arm64
+      Code: Any<Object>
+      Handler: index.handler
+      MemorySize: 1024
+      Role:
+        'Fn::GetAtt':
+          - withoutservicedeployercloudwatchcustomwidgetexecutionrole63498CC5
+          - Arn
+      Runtime: nodejs22.x
+      Tags:
+        - Key: Name
+          Value: RestateBYOC/without-service-deployer/cloudwatch-custom-widget-lambda
+      Timeout: 60
+    DependsOn:
+      - >-
+        withoutservicedeployercloudwatchcustomwidgetexecutionroleDefaultPolicyB278087E
+      - withoutservicedeployercloudwatchcustomwidgetexecutionrole63498CC5
+  withoutservicedeployercloudwatchcustomwidgetlambdacloudwatchcustomwidgetlambdaallowdatasource0EE93412:
+    Type: 'AWS::Lambda::Permission'
+    Properties:
+      Action: 'lambda:InvokeFunction'
+      FunctionName:
+        'Fn::GetAtt':
+          - withoutservicedeployercloudwatchcustomwidgetlambda09DF3572
+          - Arn
+      Principal: lambda.datasource.cloudwatch.amazonaws.com
+  withoutservicedeployermetrics12A2B44C:
+    Type: 'AWS::CloudWatch::Dashboard'
+    Properties:
+      DashboardBody:
+        'Fn::Join':
+          - ''
+          - - >-
+              {"widgets":[{"type":"metric","width":12,"height":6,"x":0,"y":0,"properties":{"view":"timeSeries","title":"Stateless
+              CPU","region":"
+            - Ref: 'AWS::Region'
+            - >-
+              ","metrics":[[{"label":"CPU","expression":"cpu /
+              1024"}],[{"expression":"SELECT AVG(CpuUtilized) FROM
+              SCHEMA(\\"ECS/ContainerInsights\\",
+              ClusterName,TaskDefinitionFamily,TaskId) WHERE
+              TaskDefinitionFamily =
+              'RestateBYOCwithoutservicedeployerstatelessdefinition466C1E01'
+              GROUP BY
+              TaskId","visible":false,"id":"cpu"}]],"annotations":{"horizontal":[{"value":16,"label":"Limit","yAxis":"left"}]},"yAxis":{"left":{"label":"vCPUs","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":0,"properties":{"view":"timeSeries","title":"Stateless
+              Memory","region":"
+            - Ref: 'AWS::Region'
+            - >-
+              ","metrics":[[{"label":"Memory","expression":"memory /
+              1024"}],[{"expression":"SELECT AVG(MemoryUtilized) FROM
+              SCHEMA(\\"ECS/ContainerInsights\\",
+              ClusterName,TaskDefinitionFamily,TaskId) WHERE
+              TaskDefinitionFamily =
+              'RestateBYOCwithoutservicedeployerstatelessdefinition466C1E01'
+              GROUP BY
+              TaskId","visible":false,"id":"memory"}]],"annotations":{"horizontal":[{"value":32,"label":"Limit","yAxis":"left"}]},"yAxis":{"left":{"label":"GiB","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":0,"y":6,"properties":{"view":"timeSeries","title":"Stateless
+              Network Tx","region":"
+            - Ref: 'AWS::Region'
+            - >-
+              ","metrics":[[{"label":"Tx","expression":"SELECT
+              AVG(NetworkTxBytes) FROM SCHEMA(\\"ECS/ContainerInsights\\",
+              ClusterName,TaskDefinitionFamily,TaskId) WHERE
+              TaskDefinitionFamily =
+              'RestateBYOCwithoutservicedeployerstatelessdefinition466C1E01'
+              GROUP BY
+              TaskId"}]],"yAxis":{"left":{"label":"Bytes/sec","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":6,"properties":{"view":"timeSeries","title":"Stateless
+              Network Rx","region":"
+            - Ref: 'AWS::Region'
+            - >-
+              ","metrics":[[{"label":"Rx","expression":"SELECT
+              AVG(NetworkRxBytes) FROM SCHEMA(\\"ECS/ContainerInsights\\",
+              ClusterName,TaskDefinitionFamily,TaskId) WHERE
+              TaskDefinitionFamily =
+              'RestateBYOCwithoutservicedeployerstatelessdefinition466C1E01'
+              GROUP BY
+              TaskId"}]],"yAxis":{"left":{"label":"Bytes/sec","showUnits":false}}}},{"type":"log","width":24,"height":6,"x":0,"y":12,"properties":{"view":"table","title":"Stateless
+              Logs","region":"region","query":"SOURCE '
+            - Ref: withoutservicedeployerstatelessdefinitionrestateLogGroupEC27F989
+            - >-
+              ' | fields @logStream, @timestamp, level, fields.message,
+              target\\n          | sort @timestamp desc\\n          | limit
+              500"}},{"type":"metric","width":12,"height":6,"x":0,"y":18,"properties":{"view":"timeSeries","title":"Stateful
+              CPU","region":"
+            - Ref: 'AWS::Region'
+            - >-
+              ","metrics":[[{"label":"CPU","expression":"cpu /
+              1024"}],[{"expression":"SELECT AVG(CpuUtilized) FROM
+              SCHEMA(\\"ECS/ContainerInsights\\",
+              ClusterName,TaskDefinitionFamily,TaskId) WHERE
+              TaskDefinitionFamily =
+              'RestateBYOCwithoutservicedeployerstatefuldefinition55E65D66'
+              GROUP BY
+              TaskId","visible":false,"id":"cpu"}]],"annotations":{"horizontal":[{"value":16,"label":"Limit","yAxis":"left"}]},"yAxis":{"left":{"label":"vCPUs","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":18,"properties":{"view":"timeSeries","title":"Stateful
+              Memory","region":"
+            - Ref: 'AWS::Region'
+            - >-
+              ","metrics":[[{"label":"Memory","expression":"memory /
+              1024"}],[{"expression":"SELECT AVG(MemoryUtilized) FROM
+              SCHEMA(\\"ECS/ContainerInsights\\",
+              ClusterName,TaskDefinitionFamily,TaskId) WHERE
+              TaskDefinitionFamily =
+              'RestateBYOCwithoutservicedeployerstatefuldefinition55E65D66'
+              GROUP BY
+              TaskId","visible":false,"id":"memory"}]],"annotations":{"horizontal":[{"value":32,"label":"Limit","yAxis":"left"}]},"yAxis":{"left":{"label":"GiB","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":0,"y":24,"properties":{"view":"timeSeries","title":"Stateful
+              Network Tx","region":"
+            - Ref: 'AWS::Region'
+            - >-
+              ","metrics":[[{"label":"Tx","expression":"SELECT
+              AVG(NetworkTxBytes) FROM SCHEMA(\\"ECS/ContainerInsights\\",
+              ClusterName,TaskDefinitionFamily,TaskId) WHERE
+              TaskDefinitionFamily =
+              'RestateBYOCwithoutservicedeployerstatefuldefinition55E65D66'
+              GROUP BY
+              TaskId"}]],"yAxis":{"left":{"label":"Bytes/sec","showUnits":false}}}},{"type":"metric","width":12,"height":6,"x":12,"y":24,"properties":{"view":"timeSeries","title":"Stateful
+              Network Rx","region":"
+            - Ref: 'AWS::Region'
+            - >-
+              ","metrics":[[{"label":"Rx","expression":"SELECT
+              AVG(NetworkRxBytes) FROM SCHEMA(\\"ECS/ContainerInsights\\",
+              ClusterName,TaskDefinitionFamily,TaskId) WHERE
+              TaskDefinitionFamily =
+              'RestateBYOCwithoutservicedeployerstatefuldefinition55E65D66'
+              GROUP BY
+              TaskId"}]],"yAxis":{"left":{"label":"Bytes/sec","showUnits":false}}}},{"type":"log","width":24,"height":6,"x":0,"y":30,"properties":{"view":"table","title":"Stateful
+              Logs","region":"region","query":"SOURCE '
+            - Ref: withoutservicedeployerstatefuldefinitionrestateLogGroupCE40C5FC
+            - >-
+              ' | fields @logStream, @timestamp, level, fields.message,
+              target\\n          | sort @timestamp desc\\n          | limit
+              500"}},{"type":"metric","width":8,"height":6,"x":0,"y":36,"properties":{"view":"timeSeries","title":"Ephemeral
+              Volume Usage (Total size 200GiB)","region":"
+            - Ref: 'AWS::Region'
+            - >-
+              ","metrics":[[{"label":"Usage","expression":"SELECT
+              MAX(EphemeralStorageUtilized) FROM
+              SCHEMA(\\"ECS/ContainerInsights\\",
+              ClusterName,TaskDefinitionFamily) WHERE TaskDefinitionFamily =
+              'RestateBYOCwithoutservicedeployerstatefuldefinition55E65D66'"}]],"annotations":{"horizontal":[{"value":200,"label":"Volume
+              size","visible":false,"yAxis":"left"}]},"yAxis":{"left":{"label":"GiB","showUnits":false}},"liveData":false}},{"type":"metric","width":8,"height":6,"x":8,"y":36,"properties":{"view":"timeSeries","title":"Volume
+              Write Throughput (Limited to 150 MiB/sec)","region":"
+            - Ref: 'AWS::Region'
+            - >-
+              ","metrics":[[{"label":"Write","expression":"RATE(count) /
+              1048576"}],[{"expression":"SELECT MAX(StorageWriteBytes) FROM
+              SCHEMA(\\"ECS/ContainerInsights\\",
+              ClusterName,TaskDefinitionFamily,TaskId) WHERE
+              TaskDefinitionFamily =
+              'RestateBYOCwithoutservicedeployerstatefuldefinition55E65D66'
+              GROUP BY
+              TaskId","visible":false,"id":"count"}]],"annotations":{"horizontal":[{"value":150,"label":"Limit","visible":false,"yAxis":"left"}]},"yAxis":{"left":{"label":"MiB/sec","showUnits":false}}}},{"type":"metric","width":8,"height":6,"x":16,"y":36,"properties":{"view":"timeSeries","title":"Volume
+              Read Throughput (Limited to 150 MiB/sec)","region":"
+            - Ref: 'AWS::Region'
+            - >-
+              ","metrics":[[{"label":"Read","expression":"RATE(count) /
+              1048576"}],[{"expression":"SELECT MAX(StorageReadBytes) FROM
+              SCHEMA(\\"ECS/ContainerInsights\\",
+              ClusterName,TaskDefinitionFamily,TaskId) WHERE
+              TaskDefinitionFamily =
+              'RestateBYOCwithoutservicedeployerstatefuldefinition55E65D66'
+              GROUP BY
+              TaskId","visible":false,"id":"count"}]],"annotations":{"horizontal":[{"value":150,"label":"Limit","visible":false,"yAxis":"left"}]},"yAxis":{"left":{"label":"MiB/sec","showUnits":false}}}},{"type":"log","width":24,"height":6,"x":0,"y":42,"properties":{"view":"table","title":"Controller
+              Logs","region":"region","query":"SOURCE '
+            - Ref: >-
+                withoutservicedeployercontrollerdefinitioncontrollerLogGroupC38FCA92
+            - >-
+              ' | fields @logStream, @timestamp, level, fields.message,
+              target\\n          | sort @timestamp desc\\n          | limit
+              500"}}]}
+      DashboardName: RestateBYOC_without-service-deployer_metrics
+  withoutservicedeployercontrolpanelDE1386C7:
+    Type: 'AWS::CloudWatch::Dashboard'
+    Properties:
+      DashboardBody:
+        'Fn::Join':
+          - ''
+          - - >-
+              {"widgets":[{"type":"custom","width":24,"height":26,"x":0,"y":0,"properties":{"endpoint":"
+            - 'Fn::GetAtt':
+                - withoutservicedeployercloudwatchcustomwidgetlambda09DF3572
+                - Arn
+            - '","params":{"command":"controlPanel","input":{"region":"'
+            - Ref: 'AWS::Region'
+            - >-
+              ","summary":{"clusterName":"RestateBYOC/without-service-deployer","restateVersion":"1.3","stackVersion":"0.2.0","metricsDashboardName":"
+            - Ref: withoutservicedeployermetrics12A2B44C
+            - '"},"resources":{"ecsClusterArn":"'
+            - 'Fn::GetAtt':
+                - withoutservicedeployerclusterC266C783
+                - Arn
+            - '","statelessServiceArn":"'
+            - Ref: withoutservicedeployerstatelessserviceService4B925097
+            - '","controllerServiceArn":"'
+            - Ref: withoutservicedeployercontrollerserviceService53E53874
+            - '","restatectlLambdaArn":"'
+            - 'Fn::GetAtt':
+                - withoutservicedeployerrestatectllambda9B5C28C5
+                - Arn
+            - >-
+              "},"connectivityAndSecurity":{"connectivity":{"loadBalancerArns":{"ingress":["
+            - Ref: withoutservicedeployersharednlb054F9DEE
+            - '"],"admin":["'
+            - Ref: withoutservicedeployersharednlb054F9DEE
+            - '"]},"addresses":{"ingress":"http://'
+            - 'Fn::GetAtt':
+                - withoutservicedeployersharednlb054F9DEE
+                - DNSName
+            - ':8080","admin":"http://'
+            - 'Fn::GetAtt':
+                - withoutservicedeployersharednlb054F9DEE
+                - DNSName
+            - ':9070","webUI":"http://'
+            - 'Fn::GetAtt':
+                - withoutservicedeployersharednlb054F9DEE
+                - DNSName
+            - ':9070/ui"}},"networking":{"vpc":"'
+            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcA2121C384D1B3CDE'
+            - '","availabilityZones":["dummy1a","dummy1b","dummy1c"],"subnets":["'
+            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet1Subnet934893E8236E2271'
+            - '","'
+            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet2Subnet7031C2BA60DCB1EE'
+            - '","'
+            - 'Fn::ImportValue': 'VPCStack:ExportsOutputRefvpcPrivateSubnet3Subnet985AC459F9514491'
+            - '"]},"security":{"securityGroups":["'
+            - 'Fn::GetAtt':
+                - withoutservicedeployersecuritygroup68EF3063
+                - GroupId
+            - '"]}},"storage":{"s3":{"bucket":"'
+            - Ref: withoutservicedeployerbucketB1987DAB
+            - >-
+              "}}}},"title":"","updateOn":{"refresh":true,"resize":true,"timeRange":true}}}]}
+      DashboardName: RestateBYOC_without-service-deployer_control-panel
+"
+`;
+
+exports[`BYOC Without service deployer 2`] = `"props.serviceDeployer.disabled must not be set to use deployService"`;
+
+exports[`BYOC Without service deployer 3`] = `"props.serviceDeployer.disabled must not be set to use register"`;

--- a/test/byoc.test.ts
+++ b/test/byoc.test.ts
@@ -35,37 +35,6 @@ describe("BYOC", () => {
     });
   });
 
-  test("With alb for admin", () => {
-    const { stack, vpc } = createStack();
-
-    const alb = new cdk.aws_elasticloadbalancingv2.ApplicationLoadBalancer(
-      stack,
-      "alb",
-      {
-        vpc,
-      },
-    );
-
-    new RestateBYOC(stack, "with-admin-alb", {
-      vpc,
-      licenseID,
-      loadBalancer: {
-        admin: {
-          applicationListenerProps: {
-            loadBalancer: alb,
-            protocol: cdk.aws_elasticloadbalancingv2.ApplicationProtocol.HTTP,
-            port: 9070,
-          },
-        },
-      },
-    });
-
-    expect(stack).toMatchCdkSnapshot({
-      ignoreAssets: true,
-      yaml: true,
-    });
-  });
-
   test("With shared alb", () => {
     const { stack, vpc } = createStack();
 
@@ -179,6 +148,33 @@ describe("BYOC", () => {
       ignoreAssets: true,
       yaml: true,
     });
+  });
+
+  test("Without service deployer", () => {
+    const { stack, vpc } = createStack();
+
+    const byoc = new RestateBYOC(stack, "without-service-deployer", {
+      vpc,
+      licenseID,
+      serviceDeployer: {
+        disabled: true,
+      },
+    });
+
+    expect(stack).toMatchCdkSnapshot({
+      ignoreAssets: true,
+      yaml: true,
+    });
+
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      byoc.deployService("abc", null as any),
+    ).toThrowErrorMatchingSnapshot();
+
+    expect(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      byoc.register(null as any),
+    ).toThrowErrorMatchingSnapshot();
   });
 });
 


### PR DESCRIPTION
- Label our exports
- Always have a shared LB (default internal) for all 3 ports, simply expose target props so that end users can make their own target groups / load balancers. Update authn docs accordingly
- Create a in-VPC service deployer lambda that uses the internal load balancer to perform registration.