### PR TITLE
Update restatectl query for 1.4.x

### DIFF
--- a/lib/lambda/cloudwatch-custom-widget/readers.mts
+++ b/lib/lambda/cloudwatch-custom-widget/readers.mts
@@ -408,7 +408,7 @@ export async function getControlPanel(
   const nodeState = restatectlSql(
     lambdaClient,
     input.resources.restatectlLambdaArn,
-    "select * from node_state",
+    "select * from nodes",
   );
   const bifrostConfig = getBifrostConfig(
     lambdaClient,


### PR DESCRIPTION
Missed splitting this one out - the DF view for nodes has changed in 1.4.x so this is required to make the query work well with the latest `restatectl` release.