### PR TITLE
Bump default Restate version to 1.4

### DIFF
--- a/lib/props.ts
+++ b/lib/props.ts
@@ -217,16 +217,22 @@ export interface RestateBYOCEBSVolumeProps {
 }
 
 export const DEFAULT_RESTATE_IMAGE =
-  "docker.restate.dev/restatedev/restate:1.3";
+  "docker.restate.dev/restatedev/restate:1.4";
 
 export const DEFAULT_RESTATE_CPU = 16384;
 export const DEFAULT_RESTATE_MEMORY_LIMIT_MIB = 32768;
 
-export type SupportedRestateVersion = `1.3.${string}` | `1.3`;
+export type SupportedRestateVersion = `1.4.${string}` | `1.4` | `1.3.2` | `1.3`;
 export function assertSupportedRestateVersion(
   version: string,
 ): asserts version is SupportedRestateVersion {
-  if (version == "1.3" || version.startsWith("1.3.")) return;
+  if (
+    version == "1.3" ||
+    version == "1.3.2" ||
+    version == "1.4" ||
+    version.startsWith("1.4.")
+  )
+    return;
   throw new Error(`Restate version ${version} is not supported by this stack`);
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@restatedev/byoc",
-  "version": "0.3.0",
+  "version": "0.4.0-dev",
   "description": "Restate Bring-your-own-cloud Construct",
   "author": "Restate Developers",
   "license": "MIT",

--- a/test/__snapshots__/byoc.test.ts.snap
+++ b/test/__snapshots__/byoc.test.ts.snap
@@ -1893,7 +1893,7 @@ exports[`BYOC Default parameters 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/default","restateVersion":"1.3","stackVersion":"0.3.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/default","restateVersion":"1.4","stackVersion":"0.4.0-dev","metricsDashboardName":"
             - Ref: defaultmetrics63974EF8
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':


### PR DESCRIPTION
Unclear if we should continue to allow 1.3.2 but just in case we might want to do some migration testing; we can take that out before the proper release.