### PR TITLE
Rename RestateBYOC to RestateEcsFargateCluster

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -24,3 +24,4 @@ jobs:
       - run: npm run build
       - run: npm run attw
       - run: npm run test
+      - run: npm run synth

--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ npm install @restatedev/byoc
 ```
 
 ```ts
-interface BYOCStackProps extends cdk.StackProps {
+interface RestateStackProps extends cdk.StackProps {
 }
 
-export class BYOCStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: BYOCStackProps) {
+export class RestateStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: RestateStackProps) {
     super(scope, id, props);
 
     const vpc = new cdk.aws_ec2.Vpc(this, "vpc", {
       maxAzs: 3,
     });
 
-    const byoc = new RestateBYOC(this, "restate-byoc", {
-      licenseID: "this-was-provided-to-you-by-restate",
+    const cluster = new RestateEcsFargateCluster(this, "restate-cluster", {
+      licenseKey: "this-was-provided-to-you-by-restate",
       vpc,
       statefulNode: {
         resources: {

--- a/docs/deployer.md
+++ b/docs/deployer.md
@@ -15,20 +15,20 @@ const service = new NodejsFunction(scope, "service", {
   entry: "handler", // use the path to your service handler
 });
 
-// create a byoc cluster
-const byoc = new RestateBYOC(this, "byoc", {
+// create a Restate cluster
+const cluster = new RestateEcsFargateCluster(this, "cluster", {
   vpc,
   ...,
 });
 // give the cluster permissions to invoke your lambda
-service.grantInvoke(byoc)
+service.grantInvoke(cluster)
 
-// create a service deployer that is in the byoc vpc
+// create a service deployer that is in the cluster vpc
 const deployer = new restate.ServiceDeployer(this, "deployer", {
-  vpc: byoc.vpc,
-  vpcSubnets: byoc.vpcSubnets,
-  securityGroups: byoc.securityGroups,
+  vpc: cluster.vpc,
+  vpcSubnets: cluster.vpcSubnets,
+  securityGroups: cluster.securityGroups,
 });
 // register the current version of the service with restate
-deployer.register(service.currentVersion, byoc);
+deployer.register(service.currentVersion, cluster);
 ```

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,3 +1,3 @@
-export { RestateBYOC } from "./byoc";
-export type { RestateBYOCProps } from "./props";
+export { RestateEcsFargateCluster } from "./byoc";
+export type { ClusterProps as RestateClusterProps } from "./props";
 export { VOLUME_POLICY } from "./volume-policy";

--- a/lib/monitoring.ts
+++ b/lib/monitoring.ts
@@ -7,9 +7,9 @@ import {
   DEFAULT_OTEL_COLLECTOR_MEMORY_LIMIT_MIB,
   DEFAULT_RESTATE_CPU,
   DEFAULT_RESTATE_MEMORY_LIMIT_MIB,
-  RestateBYOCMonitoringProps,
-  RestateBYOCOtelCollectorProps,
-  RestateBYOCProps,
+  MonitoringProps,
+  OtelCollectorProps,
+  ClusterProps,
   SupportedRestateVersion,
 } from "./props";
 import type { ControlPanelWidgetEvent } from "./lambda/cloudwatch-custom-widget/index.mjs";
@@ -45,7 +45,7 @@ export function createMonitoring(
   },
   customWidgetCode: cdk.aws_lambda.Code,
   restatectlLambda?: cdk.aws_lambda.IFunction,
-  props?: RestateBYOCProps,
+  props?: ClusterProps,
 ): {
   metricsDashboard?: cloudwatch.Dashboard;
   controlPanelDashboard?: cloudwatch.Dashboard;
@@ -151,7 +151,7 @@ export function createMetricsDashboard(
   statefulTaskDefinition: cdk.aws_ecs.FargateTaskDefinition,
   controllerTaskDefinition: cdk.aws_ecs.FargateTaskDefinition,
   customWidgetFn?: cdk.aws_lambda.IFunction,
-  props?: RestateBYOCProps,
+  props?: ClusterProps,
 ): cloudwatch.Dashboard | undefined {
   if (props?.monitoring?.dashboard?.metrics?.disabled) return;
 
@@ -509,7 +509,7 @@ function createCustomWidgetLambda(
   ecsCluster: cdk.aws_ecs.ICluster,
   code: cdk.aws_lambda.Code,
   restatectlLambda?: cdk.aws_lambda.IFunction,
-  props?: RestateBYOCMonitoringProps,
+  props?: MonitoringProps,
 ): cdk.aws_lambda.Function | undefined {
   if (!restatectlLambda || props?.dashboard?.customWidgets?.disabled) return;
 
@@ -645,7 +645,7 @@ function createCustomWidgetLambda(
 export function otelCollectorContainerProps(
   clusterName: string,
   logDriver?: cdk.aws_ecs.LogDriver,
-  otelCollectorProps?: RestateBYOCOtelCollectorProps,
+  otelCollectorProps?: OtelCollectorProps,
 ): cdk.aws_ecs.ContainerDefinitionOptions | undefined {
   if (!otelCollectorProps?.enabled) {
     return;
@@ -688,7 +688,7 @@ export function otelCollectorContainerProps(
 }
 
 function otelCollectorConfig(
-  otelCollectorProps: RestateBYOCOtelCollectorProps,
+  otelCollectorProps: OtelCollectorProps,
 ): string {
   if ("customConfig" in otelCollectorProps.configuration) {
     return otelCollectorProps.configuration.customConfig;

--- a/lib/outputs.ts
+++ b/lib/outputs.ts
@@ -1,7 +1,7 @@
 import * as cdk from "aws-cdk-lib";
-import { RestateBYOC } from "./byoc";
+import { RestateEcsFargateCluster } from "./byoc";
 
-export function createOutputs(byoc: RestateBYOC) {
+export function createOutputs(byoc: RestateEcsFargateCluster) {
   new cdk.CfnOutput(byoc, "SecurityGroups", {
     description: "The security group IDs of the cluster",
     value: cdk.Fn.join(

--- a/lib/props.ts
+++ b/lib/props.ts
@@ -1,16 +1,16 @@
 import * as cdk from "aws-cdk-lib";
 
-export interface RestateBYOCProps {
+export interface ClusterProps {
   /**
    * The name of the Restate cluster
-   * Default: The path of the RestateBYOC construct is used
+   * Default: The path of the construct is used
    */
   clusterName?: string;
   /**
-   * The License ID for the BYOC product, provided to you by Restate. This ID will be used by
-   * your controller to occasionally load a new License Key from https://license.restate.cloud.
+   * The license key for the BYOC product, provided to you by Restate. The controller uses this to
+   * occasionally validate the product license by contacting <https://license.restate.cloud>.
    */
-  licenseID: string;
+  licenseKey: string;
   /**
    * The VPC in which to run the cluster
    */
@@ -41,9 +41,9 @@ export interface RestateBYOCProps {
   securityGroups?: cdk.aws_ec2.ISecurityGroup[];
   /**
    * Configuration for the load balancer which will route to the stateless nodes.
-   * Default: See the documentation for RestateBYOCLoadBalancerProps
+   * Default: See the documentation for {@link LoadBalancerProps}
    */
-  loadBalancer?: RestateBYOCLoadBalancerProps;
+  loadBalancer?: LoadBalancerProps;
   /**
    * Human-facing addresses for Restate ports
    * Default: The address of the shared load balancer on the relevant port
@@ -69,44 +69,44 @@ export interface RestateBYOCProps {
   ecsCluster?: cdk.aws_ecs.ICluster;
   /**
    * Options for the stateless nodes, which run the http-ingress and admin roles
-   * Default: See the documentation for RestateBYOCStatelessProps
+   * Default: See the documentation for {@link StatelessNodeProps}
    */
-  statelessNode?: RestateBYOCStatelessProps;
+  statelessNode?: StatelessNodeProps;
   /**
    * Options for the stateful nodes, which run the log-server and worker roles.
-   * Default: See the documentation for RestateBYOCStatefulProps
+   * Default: See the documentation for {@link StatefulNodeProps}
    */
-  statefulNode?: RestateBYOCStatefulProps;
+  statefulNode?: StatefulNodeProps;
   /**
-   * Fargate task configurables for the restate nodes
+   * Fargate task configurables for the Restate nodes
    * Defaults:
     - An execution and task role will be created by this construct
     - awsLogs log driver will be used with a `restate` stream prefix.
     - execute command is not allowed
     - ARM cpu architecture
    */
-  restateTasks?: Partial<RestateBYOCTaskProps>;
+  restateTasks?: Partial<TaskProps>;
   /**
    * Options for the controller
-   * Default: See the documentation for RestateBYOCControllerProps
+   * Default: See the documentation for {@link ControllerProps}
    */
-  controller?: RestateBYOCControllerProps;
+  controller?: ControllerProps;
   /**
    * Options for the restatectl lambda
-   * Default: See the documentation for RestateBYOCRestatectlProps
+   * Default: See the documentation for {@link RestatectlProps}
    */
-  restatectl?: RestateBYOCRestatectlProps;
+  restatectl?: RestatectlProps;
   /**
    * Options for the fargate task retirement watcher
-   * Default: See the documentation for RestateBYOCRetirementWatcherProps
+   * Default: See the documentation for {@link TaskRetirementWatcherProps}
    */
-  retirementWatcher?: RestateBYOCRetirementWatcherProps;
+  retirementWatcher?: TaskRetirementWatcherProps;
 
   /**
    * Options for monitoring
-   * Default: See the documentation for RestateBYOCMonitoringProps
+   * Default: See the documentation for {@link MonitoringProps}
    */
-  monitoring?: RestateBYOCMonitoringProps;
+  monitoring?: MonitoringProps;
 
   /**
    * @internal
@@ -142,7 +142,7 @@ export type LoadBalancerSource =
       nlb: cdk.aws_elasticloadbalancingv2.INetworkLoadBalancer;
     };
 
-export interface RestateBYOCLoadBalancerProps {
+export interface LoadBalancerProps {
   /**
    * Options for the shared load balancer which is used for internal ingress, admin, and node traffic on default ports.
    * The restatectl lambda needs access to the node port.
@@ -160,7 +160,7 @@ export interface RestateBYOCLoadBalancerProps {
 export const DEFAULT_STATELESS_DESIRED_COUNT = 3;
 export const DEFAULT_PARTITIONS = 128;
 
-export interface RestateBYOCStatelessProps extends RestateBYOCNodeProps {
+export interface StatelessNodeProps extends NodeProps {
   /**
    * Configures the default replication factor to be used by the replicated loglets and the partition processors.
    * Note that this value only impacts the cluster initial provisioning and will not be respected after the cluster has been provisioned.
@@ -186,7 +186,7 @@ export interface RestateBYOCStatelessProps extends RestateBYOCNodeProps {
 
 export const DEFAULT_STATEFUL_NODES_PER_AZ = 1;
 
-export interface RestateBYOCStatefulProps extends RestateBYOCNodeProps {
+export interface StatefulNodeProps extends NodeProps {
   /**
    * The number of stateful nodes to run per AWS availability zone.
    * Default: 1
@@ -197,10 +197,10 @@ export interface RestateBYOCStatefulProps extends RestateBYOCNodeProps {
    * Fargate ephemeral storage, which is backed by an EBS gp2 volume (600 baseline IOPS).
    * Default: No EBS volume
    */
-  ebsVolume?: RestateBYOCEBSVolumeProps;
+  ebsVolume?: EbsVolumeProps;
 }
 
-export interface RestateBYOCEBSVolumeProps {
+export interface EbsVolumeProps {
   /**
    * The type of the volume to create for each node
    * Default: The default of the CreateVolume API, currently `gp2`
@@ -246,7 +246,7 @@ export function assertSupportedRestateVersion(
   throw new Error(`Restate version ${version} is not supported by this stack`);
 }
 
-export interface RestateBYOCNodeProps {
+export interface NodeProps {
   /**
    * The Restate image to use for the node
    *
@@ -297,7 +297,7 @@ export const DEFAULT_CONTROLLER_SNAPSHOT_RETENTION = "24h";
 /**
  * Properties for configuring the controller
  */
-export interface RestateBYOCControllerProps {
+export interface ControllerProps {
   /**
    * The controller image to use
    * Default: docker.restate.dev/restatedev/restate-fargate-controller:0.1
@@ -324,7 +324,7 @@ export interface RestateBYOCControllerProps {
     - execute command is not allowed
     - ARM cpu architecture
    */
-  tasks?: Partial<RestateBYOCTaskProps>;
+  tasks?: Partial<TaskProps>;
 
   /**
    * Configuration for EBS snapshot retention
@@ -344,7 +344,7 @@ export interface RestateBYOCControllerProps {
   };
 }
 
-export interface RestateBYOCTaskProps {
+export interface TaskProps {
   /**
    * The task execution role for the task, assumable by `ecs-tasks.amazonaws.com`
    */
@@ -367,7 +367,7 @@ export interface RestateBYOCTaskProps {
   cpuArchitecture: cdk.aws_ecs.CpuArchitecture;
 }
 
-export interface RestateBYOCRestatectlProps {
+export interface RestatectlProps {
   /**
    * If true, do not create a restatectl lambda. Note this lambda is also required for CloudWatch custom widgets.
    * Default: false
@@ -381,7 +381,7 @@ export interface RestateBYOCRestatectlProps {
   executionRole?: cdk.aws_iam.IRole;
 }
 
-export interface RestateBYOCRetirementWatcherProps {
+export interface TaskRetirementWatcherProps {
   /**
    * If true, do not create a retirement watcher. This means that retirement notifications from AWS health must be handled in some other way.
    * Default: false
@@ -400,7 +400,7 @@ export const DEFAULT_OTEL_COLLECTOR_IMAGE =
 export const DEFAULT_OTEL_COLLECTOR_CPU = 256;
 export const DEFAULT_OTEL_COLLECTOR_MEMORY_LIMIT_MIB = 512;
 
-export interface RestateBYOCOtelCollectorProps {
+export interface OtelCollectorProps {
   /**
    * If true, create OTEL collector sidecars for telemetry collection.
    * Default: false
@@ -512,7 +512,7 @@ export interface RestateBYOCOtelCollectorProps {
       };
 }
 
-export interface RestateBYOCMonitoringProps {
+export interface MonitoringProps {
   dashboard?: {
     metrics?: {
       /**
@@ -563,5 +563,5 @@ export interface RestateBYOCMonitoringProps {
    * Options for OpenTelemetry collector sidecars
    * Default: OTEL collector sidecars are disabled
    */
-  otelCollector?: RestateBYOCOtelCollectorProps;
+  otelCollector?: OtelCollectorProps;
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "watch": "tsc -w",
     "test": "jest",
     "cdk": "cdk",
-    "ts-node": "ts-node"
+    "ts-node": "ts-node",
+    "tsx": "tsx",
+    "synth": "cdk --app ./templates/medium.ts synth --quiet && cdk --app ./templates/xlarge.ts synth --quiet",
+    "check": "npm run lint && npm run build && npm run attw && npm run test && npm run synth"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.4",

--- a/templates/base.ts
+++ b/templates/base.ts
@@ -1,7 +1,7 @@
 import * as cdk from "aws-cdk-lib";
-import { RestateBYOC } from "../lib/byoc";
+import { RestateEcsFargateCluster } from "../lib/byoc";
 import { Construct } from "constructs";
-import type { RestateBYOCEBSVolumeProps } from "../lib/props";
+import type { EbsVolumeProps } from "../lib/props";
 
 interface RestateBYOCStackProps extends cdk.StackProps {
   statelessNode: {
@@ -15,7 +15,7 @@ interface RestateBYOCStackProps extends cdk.StackProps {
       cpu: number;
       memoryLimitMiB: number;
     };
-    ebsVolume: Omit<RestateBYOCEBSVolumeProps, "sizeInGiB">;
+    ebsVolume: Omit<EbsVolumeProps, "sizeInGiB">;
   };
 }
 
@@ -54,8 +54,8 @@ export class RestateBYOCStack extends cdk.Stack {
       ],
     });
 
-    const licenseID = new cdk.CfnParameter(this, "LicenceId", {
-      description: "The License ID provided to you by Restate.",
+    const licenseKey = new cdk.CfnParameter(this, "LicenseKey", {
+      description: "The License key provided to you by Restate.",
       type: "String",
       noEcho: true,
     });
@@ -73,9 +73,9 @@ export class RestateBYOCStack extends cdk.Stack {
       type: "Number",
     });
 
-    new RestateBYOC(this, "RestateBYOC", {
+    new RestateEcsFargateCluster(this, "RestateBYOC", {
       vpc,
-      licenseID: licenseID.valueAsString,
+      licenseKey: licenseKey.valueAsString,
       statelessNode: {
         resources: props.statelessNode.resources,
         defaultReplication: { zone: 2 },

--- a/test/__snapshots__/byoc.test.ts.snap
+++ b/test/__snapshots__/byoc.test.ts.snap
@@ -910,7 +910,7 @@ exports[`BYOC Default parameters 1`] = `
                 'Fn::GetAtt':
                   - defaultcluster07071299
                   - Arn
-            - Name: CONTROLLER_LICENSE_ID
+            - Name: CONTROLLER_LICENSE_KEY
               Value: foo
             - Name:
                 'Fn::Join':
@@ -2933,7 +2933,7 @@ exports[`BYOC With otel collector 1`] = `
                 'Fn::GetAtt':
                   - withotelcollectorcluster09679981
                   - Arn
-            - Name: CONTROLLER_LICENSE_ID
+            - Name: CONTROLLER_LICENSE_KEY
               Value: foo
             - Name:
                 'Fn::Join':

--- a/test/byoc.test.ts
+++ b/test/byoc.test.ts
@@ -1,13 +1,13 @@
 import * as cdk from "aws-cdk-lib";
 import "jest-cdk-snapshot";
-import { RestateBYOC } from "../lib/byoc";
+import { RestateEcsFargateCluster } from "../lib/byoc";
 
 describe("BYOC", () => {
-  const licenseID = "foo";
+  const licenseKey = "foo";
   test("Default parameters", () => {
     const { stack, vpc } = createStack();
 
-    new RestateBYOC(stack, "default", { vpc, licenseID });
+    new RestateEcsFargateCluster(stack, "default", { vpc, licenseKey });
 
     expect(stack).toMatchCdkSnapshot({
       ignoreAssets: true,
@@ -18,9 +18,9 @@ describe("BYOC", () => {
   test("With volume", () => {
     const { stack, vpc } = createStack();
 
-    new RestateBYOC(stack, "with-volume", {
+    new RestateEcsFargateCluster(stack, "with-volume", {
       vpc,
-      licenseID,
+      licenseKey,
       statefulNode: {
         ebsVolume: {
           sizeInGiB: 200,
@@ -35,9 +35,9 @@ describe("BYOC", () => {
 
     expect(
       () =>
-        new RestateBYOC(stack, "too-few-azs", {
+        new RestateEcsFargateCluster(stack, "too-few-azs", {
           vpc,
-          licenseID,
+          licenseKey,
           subnets: {
             availabilityZones: stack.availabilityZones.slice(0, 2),
           },
@@ -48,9 +48,9 @@ describe("BYOC", () => {
   test("With one az", () => {
     const { stack, vpc } = createStack();
 
-    new RestateBYOC(stack, "one-az", {
+    new RestateEcsFargateCluster(stack, "one-az", {
       vpc,
-      licenseID,
+      licenseKey,
       statelessNode: {
         defaultReplication: { node: 2 },
       },
@@ -63,9 +63,9 @@ describe("BYOC", () => {
   test("Without metrics dashboard", () => {
     const { stack, vpc } = createStack();
 
-    new RestateBYOC(stack, "without-metrics-dashboard", {
+    new RestateEcsFargateCluster(stack, "without-metrics-dashboard", {
       vpc,
-      licenseID,
+      licenseKey,
       monitoring: {
         dashboard: {
           metrics: {
@@ -79,9 +79,9 @@ describe("BYOC", () => {
   test("Without control panel", () => {
     const { stack, vpc } = createStack();
 
-    new RestateBYOC(stack, "without-control-panel", {
+    new RestateEcsFargateCluster(stack, "without-control-panel", {
       vpc,
-      licenseID,
+      licenseKey,
       monitoring: {
         dashboard: {
           controlPanel: {
@@ -95,9 +95,9 @@ describe("BYOC", () => {
   test("Without custom widget lambda", () => {
     const { stack, vpc } = createStack();
 
-    new RestateBYOC(stack, "without-custom-widget-lambda", {
+    new RestateEcsFargateCluster(stack, "without-custom-widget-lambda", {
       vpc,
-      licenseID,
+      licenseKey,
       monitoring: {
         dashboard: {
           customWidgets: { disabled: true },
@@ -109,9 +109,9 @@ describe("BYOC", () => {
   test("Without snapshot retention", () => {
     const { stack, vpc } = createStack();
 
-    new RestateBYOC(stack, "without-snapshot-retention", {
+    new RestateEcsFargateCluster(stack, "without-snapshot-retention", {
       vpc,
-      licenseID,
+      licenseKey,
       controller: {
         snapshotRetention: {
           disabled: true,
@@ -123,9 +123,9 @@ describe("BYOC", () => {
   test("With admin ALB target group", () => {
     const { stack, vpc } = createStack();
 
-    const byoc = new RestateBYOC(stack, "with-alb-target-groups", {
+    const byoc = new RestateEcsFargateCluster(stack, "with-alb-target-groups", {
       vpc,
-      licenseID,
+      licenseKey,
     });
 
     const publicAlb =
@@ -172,9 +172,9 @@ describe("BYOC", () => {
   test("With otel collector", () => {
     const { stack, vpc } = createStack();
 
-    new RestateBYOC(stack, "with-otel-collector", {
+    new RestateEcsFargateCluster(stack, "with-otel-collector", {
       vpc,
-      licenseID,
+      licenseKey,
       monitoring: {
         otelCollector: {
           enabled: true,

--- a/test/e2e/cdk-app.ts
+++ b/test/e2e/cdk-app.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env npx tsx
+#!/usr/bin/env -S npm run tsx
 //
 // Local entrypoint for deploying the e2e test stack directly outside of test runner
 //

--- a/test/e2e/cluster-stack.ts
+++ b/test/e2e/cluster-stack.ts
@@ -1,4 +1,4 @@
-import { RestateBYOC } from "@restatedev/byoc";
+import { RestateEcsFargateCluster } from "@restatedev/byoc";
 import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 import path from "path";
@@ -41,8 +41,8 @@ export class RestateClusterStack extends cdk.Stack {
       autoDeleteObjects: true,
     });
 
-    const restate = new RestateBYOC(this, "restate-byoc", {
-      licenseID: props.licenseKey,
+    const restate = new RestateEcsFargateCluster(this, "restate-cluster", {
+      licenseKey: props.licenseKey,
       vpc,
       objectStorage: {
         bucket,


### PR DESCRIPTION
Primarily focused on the top-level construct, but also a large number of property types which seem to have unnecessary `RestateBYOC-` prefixes. Additionally this change also renames the property `licenseID` to `licenseKey`.