### PR TITLE
Bump @restatedev/restate-cdk to 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@aws-sdk/client-s3": "^3.817.0",
         "@aws-sdk/client-s3-control": "^3.817.0",
         "@eslint/js": "^9.25.1",
-        "@restatedev/restate-cdk": "0.0.0-SNAPSHOT-20250521082206",
+        "@restatedev/restate-cdk": "^1.4.0",
         "@restatedev/restate-sdk": "^1.7.3",
         "@types/aws-lambda": "^8.10.148",
         "@types/jest": "^29.5.14",
@@ -14830,9 +14830,9 @@
       }
     },
     "node_modules/@restatedev/restate-cdk": {
-      "version": "0.0.0-SNAPSHOT-20250521082206",
-      "resolved": "https://registry.npmjs.org/@restatedev/restate-cdk/-/restate-cdk-0.0.0-SNAPSHOT-20250521082206.tgz",
-      "integrity": "sha512-an3EYXCwm35zc8zAzFtOk60hVRqCYcy3xFk5ddXplpbwdHy4dC0R6yRDjmxLFBBg5739mET9tbWFtwL8Ao6D7g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@restatedev/restate-cdk/-/restate-cdk-1.4.0.tgz",
+      "integrity": "sha512-CZDBX40C2qLRj8pLmoNkfDKCVhY0h5RIKjipWFixgFCdzVL+NDY0zWhQAckOwkboWokaagA/CGB2/935kBFXag==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@aws-sdk/client-s3": "^3.817.0",
     "@aws-sdk/client-s3-control": "^3.817.0",
     "@eslint/js": "^9.25.1",
-    "@restatedev/restate-cdk": "0.0.0-SNAPSHOT-20250521082206",
+    "@restatedev/restate-cdk": "^1.4.0",
     "@restatedev/restate-sdk": "^1.7.3",
     "@types/aws-lambda": "^8.10.148",
     "@types/jest": "^29.5.14",


### PR DESCRIPTION
Passing e2e test: https://github.com/restatedev/byoc/actions/runs/16494861929/job/46638062988