### PR TITLE
Tolerate undefined leader

### DIFF
--- a/lib/lambda/cloudwatch-custom-widget/control-panel.mts
+++ b/lib/lambda/cloudwatch-custom-widget/control-panel.mts
@@ -785,15 +785,7 @@ export async function controlPanel(
     { name: "Leader" },
     { name: "Applied LSN", compare: numericCompare },
     { name: "Durable LSN", compare: numericCompare },
-    {
-      name: "Archived LSN",
-      compare: (a: string, b: string) => {
-        if (a == "-" && b == "-") return 0;
-        if (a == "-" && b != "-") return -1;
-        if (a != "-" && b == "-") return 1;
-        return numericCompare(a, b);
-      },
-    },
+    { name: "Archived LSN", compare: numericCompare },
     { name: "LSN Lag", compare: numericCompare },
     { name: "Last update" },
   ];

--- a/lib/lambda/cloudwatch-custom-widget/styles.mts
+++ b/lib/lambda/cloudwatch-custom-widget/styles.mts
@@ -1245,7 +1245,8 @@ export function paginatedTable(
   );
 
   const columnIndices: number[][] = tableHeaders.flatMap((header, col) => {
-    const compare = header.compare ?? ((a, b) => a.localeCompare(b));
+    const compare =
+      header.compare ?? ((a, b) => (a ?? "").localeCompare(b ?? ""));
 
     // an array where the first index is the first row index by this sort order, etc
     const sortedAsc = [...Array(rows.length).keys()].sort(


### PR DESCRIPTION
Some fields in restatesql are optional and can show up as missing json fields. Our types should reflect this, so we can check for it.

Also, be more tolerant of undefined strings when comparing strings for table ordering.