### PR TITLE
Bump Restate to 1.6.2

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -326,8 +326,8 @@ export class RestateExampleStack extends cdk.Stack {
         defaultReplication: { zone: 2 },
         defaultPartitions: 128,
         ingressAdvertisedAddress: "internal-nlb-address:8080", // derived from load balancer
-        restateImage: "docker.restate.dev/restatedev/restate:1.4",
-        restateVersion: "1.4", // derived from restateImage,
+        restateImage: "docker.restate.dev/restatedev/restate:1.6",
+        restateVersion: "1.6", // derived from restateImage,
         environment: {},
       },
       statefulNode: {
@@ -336,8 +336,8 @@ export class RestateExampleStack extends cdk.Stack {
           cpu: 16384,
           memoryLimitMiB: 32768,
         },
-        restateImage: "docker.restate.dev/restatedev/restate:1.4",
-        restateVersion: "1.4", // derived from restateImage
+        restateImage: "docker.restate.dev/restatedev/restate:1.6",
+        restateVersion: "1.6", // derived from restateImage
         environment: {},
       },
       controller: {

--- a/lib/byoc.ts
+++ b/lib/byoc.ts
@@ -1863,19 +1863,22 @@ function createRestatectl(
   return { fn, logGroup };
 }
 
-// RESTATE_NODE_NAME: ECS task UUID (last segment of the task ARN). Restate 1.6+ creates a
-// unix socket under <data-dir>/<node-name>/fabric.sock; the full task ARN exceeds SUN_LEN (108).
+// RESTATE_NODE_NAME: task ARN
 // RESTATE_LOCATION: region.availability-zone
 // RESTATE_ADVERTISED_ADDRESS: container IPv4 address
+// RESTATE_LISTEN_MODE: force TCP for the message-fabric listener. The default unix-socket mode in
+// Restate 1.6+ builds a path of the form <data-dir>/<node-name>/fabric.sock, which exceeds SUN_LEN
+// (108) when the node name is the full ECS task ARN.
 // RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE: 75% of container's memory limit
 // RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET: evaluate math in the string env var
 const statefulEntryPointScript = String.raw`
 curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4 -o container-metadata && \
 curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4/task -o task-metadata && \
 export \
-  RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \
+  RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \
   RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \
   RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \
+  RESTATE_LISTEN_MODE=tcp \
   RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \
   RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
 exec restate-server
@@ -1885,9 +1888,10 @@ const statelessEntryPointScript = String.raw`
 curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4 -o container-metadata && \
 curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4/task -o task-metadata && \
 export \
-  RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \
+  RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \
   RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \
-  RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+  RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \
+  RESTATE_LISTEN_MODE=tcp
 exec restate-server
 `;
 

--- a/lib/byoc.ts
+++ b/lib/byoc.ts
@@ -1863,7 +1863,8 @@ function createRestatectl(
   return { fn, logGroup };
 }
 
-// RESTATE_NODE_NAME: task ARN
+// RESTATE_NODE_NAME: ECS task UUID (last segment of the task ARN). Restate 1.6+ creates a
+// unix socket under <data-dir>/<node-name>/fabric.sock; the full task ARN exceeds SUN_LEN (108).
 // RESTATE_LOCATION: region.availability-zone
 // RESTATE_ADVERTISED_ADDRESS: container IPv4 address
 // RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE: 75% of container's memory limit
@@ -1872,7 +1873,7 @@ const statefulEntryPointScript = String.raw`
 curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4 -o container-metadata && \
 curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4/task -o task-metadata && \
 export \
-  RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \
+  RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \
   RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \
   RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \
   RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \
@@ -1884,7 +1885,7 @@ const statelessEntryPointScript = String.raw`
 curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4 -o container-metadata && \
 curl --no-progress-meter $ECS_CONTAINER_METADATA_URI_V4/task -o task-metadata && \
 export \
-  RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \
+  RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \
   RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \
   RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
 exec restate-server

--- a/lib/props.ts
+++ b/lib/props.ts
@@ -280,12 +280,14 @@ export interface EbsVolumeProps {
 }
 
 export const DEFAULT_RESTATE_IMAGE =
-  "docker.restate.dev/restatedev/restate:1.5";
+  "docker.restate.dev/restatedev/restate:1.6";
 
 export const DEFAULT_RESTATE_CPU = 16384;
 export const DEFAULT_RESTATE_MEMORY_LIMIT_MIB = 32768;
 
 export type SupportedRestateVersion =
+  | `1.6.${string}`
+  | `1.6`
   | `1.5.${string}`
   | `1.5`
   | `1.4.${string}`
@@ -295,6 +297,7 @@ export function assertSupportedRestateVersion(
 ): asserts version is SupportedRestateVersion {
   if (version == "1.4" || version.startsWith("1.4.")) return;
   if (version == "1.5" || version.startsWith("1.5.")) return;
+  if (version == "1.6" || version.startsWith("1.6.")) return;
   throw new Error(`Restate version ${version} is not supported by this stack`);
 }
 
@@ -302,7 +305,7 @@ export interface NodeProps {
   /**
    * The Restate image to use for the node
    *
-   * Default: docker.restate.dev/restatedev/restate:1.4
+   * Default: docker.restate.dev/restatedev/restate:1.6
    */
   restateImage?: string;
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   ],
   "scripts": {
     "attw": "attw --pack",
-    "download-restatectl": "mkdir -p lib/lambda/restatectl && curl -L https://restate.gateway.scarf.sh/v1.4.2/restatectl-aarch64-unknown-linux-musl.tar.xz | tar -Jx --strip-components=1 -C lib/lambda/restatectl restatectl-aarch64-unknown-linux-musl/restatectl",
+    "download-restatectl": "mkdir -p lib/lambda/restatectl && curl -L https://restate.gateway.scarf.sh/v1.6.2/restatectl-aarch64-unknown-linux-musl.tar.xz | tar -Jx --strip-components=1 -C lib/lambda/restatectl restatectl-aarch64-unknown-linux-musl/restatectl",
     "publish-stack": "./artifacts/publish_stack.mts",
     "lint": "eslint",
     "build": "tsc",

--- a/test/__snapshots__/byoc.test.ts.snap
+++ b/test/__snapshots__/byoc.test.ts.snap
@@ -254,7 +254,7 @@ exports[`BYOC Container Insights defaults to enhanced 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -425,7 +425,7 @@ exports[`BYOC Container Insights defaults to enhanced 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -2230,7 +2230,7 @@ exports[`BYOC Dashboards can be completely disabled 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -2401,7 +2401,7 @@ exports[`BYOC Dashboards can be completely disabled 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -4016,7 +4016,7 @@ exports[`BYOC Default parameters 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -4187,7 +4187,7 @@ exports[`BYOC Default parameters 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -6002,7 +6002,7 @@ exports[`BYOC Log groups can be customized after creation 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -6173,7 +6173,7 @@ exports[`BYOC Log groups can be customized after creation 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -8016,7 +8016,7 @@ exports[`BYOC Retirement watcher queue can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -8187,7 +8187,7 @@ exports[`BYOC Retirement watcher queue can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -10033,7 +10033,7 @@ exports[`BYOC Retirement watcher with KMS encryption key 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -10204,7 +10204,7 @@ exports[`BYOC Retirement watcher with KMS encryption key 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -12027,7 +12027,7 @@ exports[`BYOC Set up custom ALB for authenticated access 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -12203,7 +12203,7 @@ exports[`BYOC Set up custom ALB for authenticated access 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -14168,7 +14168,7 @@ exports[`BYOC Stateless service can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -14325,7 +14325,7 @@ exports[`BYOC Stateless service can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -16225,7 +16225,7 @@ exports[`BYOC Task log driver mode can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -16397,7 +16397,7 @@ exports[`BYOC Task log driver mode can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -18205,7 +18205,7 @@ exports[`BYOC With cluster name 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -18376,7 +18376,7 @@ exports[`BYOC With cluster name 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -20147,7 +20147,7 @@ exports[`BYOC With existing bucket 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -20308,7 +20308,7 @@ exports[`BYOC With existing bucket 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -22097,7 +22097,7 @@ exports[`BYOC With otel collector 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -22298,7 +22298,7 @@ exports[`BYOC With otel collector 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
@@ -24088,7 +24088,7 @@ exports[`BYOC With specific SG and subnets 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
               exec restate-server
@@ -24258,7 +24258,7 @@ exports[`BYOC With specific SG and subnets 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\

--- a/test/__snapshots__/byoc.test.ts.snap
+++ b/test/__snapshots__/byoc.test.ts.snap
@@ -1894,7 +1894,7 @@ exports[`BYOC Container Insights defaults to enhanced 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/default-insights","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/default-insights","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: defaultinsightsmetrics6D653E2B
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':
@@ -5656,7 +5656,7 @@ exports[`BYOC Default parameters 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/default","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/default","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: defaultmetrics63974EF8
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':
@@ -7642,7 +7642,7 @@ exports[`BYOC Log groups can be customized after creation 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/test","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/test","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: testmetricsAAAB7FF4
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':
@@ -9668,7 +9668,7 @@ exports[`BYOC Retirement watcher queue can be customized 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/test","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/test","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: testmetricsAAAB7FF4
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':
@@ -11676,7 +11676,7 @@ exports[`BYOC Retirement watcher with KMS encryption key 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/test","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/test","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: testmetricsAAAB7FF4
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':
@@ -13672,7 +13672,7 @@ exports[`BYOC Set up custom ALB for authenticated access 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/test","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/test","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: testmetricsAAAB7FF4
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':
@@ -15800,7 +15800,7 @@ exports[`BYOC Stateless service can be customized 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/custom-cluster","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/custom-cluster","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: customclustermetrics3880FE63
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':
@@ -17868,7 +17868,7 @@ exports[`BYOC Task log driver mode can be customized 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/test","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/test","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: testmetricsAAAB7FF4
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':
@@ -19845,7 +19845,7 @@ exports[`BYOC With cluster name 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"restate-byoc-cluster","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"restate-byoc-cluster","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: withclusternamemetrics035F2329
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':
@@ -21763,7 +21763,7 @@ exports[`BYOC With existing bucket 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/with-cluster-name","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/with-cluster-name","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: withclusternamemetrics035F2329
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':
@@ -23801,7 +23801,7 @@ exports[`BYOC With otel collector 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/with-otel-collector","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/with-otel-collector","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: withotelcollectormetrics493AA233
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':
@@ -25707,7 +25707,7 @@ exports[`BYOC With specific SG and subnets 1`] = `
             - '","params":{"command":"controlPanel","input":{"region":"'
             - Ref: 'AWS::Region'
             - >-
-              ","summary":{"clusterName":"RestateBYOC/with-vpc-subnet","restateVersion":"1.5","stackVersion":"0.5.0","metricsDashboardName":"
+              ","summary":{"clusterName":"RestateBYOC/with-vpc-subnet","restateVersion":"1.6","stackVersion":"0.5.0","metricsDashboardName":"
             - Ref: withvpcsubnetmetrics67F0AF3D
             - '"},"resources":{"ecsClusterArn":"'
             - 'Fn::GetAtt':

--- a/test/__snapshots__/byoc.test.ts.snap
+++ b/test/__snapshots__/byoc.test.ts.snap
@@ -254,9 +254,10 @@ exports[`BYOC Container Insights defaults to enhanced 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -425,9 +426,10 @@ exports[`BYOC Container Insights defaults to enhanced 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -2230,9 +2232,10 @@ exports[`BYOC Dashboards can be completely disabled 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -2401,9 +2404,10 @@ exports[`BYOC Dashboards can be completely disabled 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -4016,9 +4020,10 @@ exports[`BYOC Default parameters 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -4187,9 +4192,10 @@ exports[`BYOC Default parameters 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -6002,9 +6008,10 @@ exports[`BYOC Log groups can be customized after creation 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -6173,9 +6180,10 @@ exports[`BYOC Log groups can be customized after creation 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -8016,9 +8024,10 @@ exports[`BYOC Retirement watcher queue can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -8187,9 +8196,10 @@ exports[`BYOC Retirement watcher queue can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -10033,9 +10043,10 @@ exports[`BYOC Retirement watcher with KMS encryption key 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -10204,9 +10215,10 @@ exports[`BYOC Retirement watcher with KMS encryption key 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -12027,9 +12039,10 @@ exports[`BYOC Set up custom ALB for authenticated access 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -12203,9 +12216,10 @@ exports[`BYOC Set up custom ALB for authenticated access 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -14168,9 +14182,10 @@ exports[`BYOC Stateless service can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -14325,9 +14340,10 @@ exports[`BYOC Stateless service can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -16225,9 +16241,10 @@ exports[`BYOC Task log driver mode can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -16397,9 +16414,10 @@ exports[`BYOC Task log driver mode can be customized 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -18205,9 +18223,10 @@ exports[`BYOC With cluster name 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -18376,9 +18395,10 @@ exports[`BYOC With cluster name 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -20147,9 +20167,10 @@ exports[`BYOC With existing bucket 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -20308,9 +20329,10 @@ exports[`BYOC With existing bucket 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -22097,9 +22119,10 @@ exports[`BYOC With otel collector 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -22298,9 +22321,10 @@ exports[`BYOC With otel collector 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server
@@ -24088,9 +24112,10 @@ exports[`BYOC With specific SG and subnets 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
-                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122"
+                RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp
               exec restate-server
           Environment:
             - Name: RESTATE_LOG_FORMAT
@@ -24258,9 +24283,10 @@ exports[`BYOC With specific SG and subnets 1`] = `
               task-metadata && \\
 
               export \\
-                RESTATE_NODE_NAME=$(jq -r '.TaskARN | split("/") | last' task-metadata) \\
+                RESTATE_NODE_NAME=$(jq -r '.TaskARN' task-metadata) \\
                 RESTATE_LOCATION="$AWS_REGION.$(jq -r '.AvailabilityZone' task-metadata)" \\
                 RESTATE_ADVERTISED_ADDRESS="http://$(jq -r '.Networks[0].IPv4Addresses[0]' container-metadata):5122" \\
+                RESTATE_LISTEN_MODE=tcp \\
                 RESTATE_ROCKSDB_TOTAL_MEMORY_SIZE="$(($(jq -r '.Limits.Memory' container-metadata) * 3 / 4))MiB" \\
                 RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET=$(("$RESTATE_WORKER__STORAGE__NUM_PARTITIONS_TO_SHARE_MEMORY_BUDGET"))
               exec restate-server

--- a/test/e2e/cluster-stack.ts
+++ b/test/e2e/cluster-stack.ts
@@ -52,7 +52,7 @@ export class RestateClusterStack extends cdk.Stack {
       },
       statefulNode: {
         restateImage: "ghcr.io/restatedev/restate:main",
-        restateVersion: "1.4.x",
+        restateVersion: "1.6.x",
         resources: {
           cpu: 512,
           memoryLimitMiB: 1024,
@@ -70,7 +70,7 @@ export class RestateClusterStack extends cdk.Stack {
       },
       statelessNode: {
         restateImage: "ghcr.io/restatedev/restate:main",
-        restateVersion: "1.4.x",
+        restateVersion: "1.6.x",
         resources: {
           cpu: 512,
           memoryLimitMiB: 1024,


### PR DESCRIPTION
## Summary
- Add `1.6.x` to `SupportedRestateVersion` and bump `DEFAULT_RESTATE_IMAGE` to `docker.restate.dev/restatedev/restate:1.6`
- Bump bundled `restatectl` download to v1.6.2
- Update e2e cluster stack to set `restateVersion: "1.6.x"` (image stays on `:main`)
- Update docs and snapshots accordingly

## Note: forcing TCP for the message-fabric listener
Restate 1.6 introduces a unix-socket listener for the message-fabric, with the socket path derived as `<data-dir>/<node-name>/fabric.sock`. We name nodes after the full ECS task ARN (~136 chars), which pushes the path past Linux's `SUN_LEN` limit of 108 bytes and causes the server to fail at startup with `path must be shorter than SUN_LEN` (RT0004).

Rather than shorten the node name (which would break the fargate-controller's task→node lookup), the entrypoint scripts now set `RESTATE_LISTEN_MODE=tcp` on both stateful and stateless containers. This bypasses the unix socket entirely; nodes still talk to each other over TCP via `RESTATE_ADVERTISED_ADDRESS`.

## Test plan
- [x] [e2e test workflow passing](https://github.com/restatedev/byoc/actions/runs/25448535774/job/74659209452) ✅