### PR TITLE
Add licenseToken prop for offline controller operation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,28 @@ new cdk.CfnOutput(this, "dashboardName", {
 
 On successful deployment, the stack outputs will show the cluster's ingress and admin URLs, and CloudWatch dashboard name.
 
+### Offline operation with a pre-issued license token
+
+By default the controller periodically contacts `https://license.restate.cloud` to validate the license. If your deployment environment cannot reach that endpoint, ask Restate for a pre-issued license JWT for your `licenseKey` and pass it via the optional `licenseToken` prop. When set, the controller validates the token locally on startup, never contacts the license server, and exits cleanly when the token expires.
+
+The token is sensitive material; store it in AWS Secrets Manager (or SSM Parameter Store) and wire it through using `cdk.aws_ecs.Secret` so the value is fetched at task start instead of being baked into the CloudFormation template:
+
+```ts
+const licenseTokenSecret = cdk.aws_secretsmanager.Secret.fromSecretCompleteArn(
+  this,
+  "restate-license-token",
+  "arn:aws:secretsmanager:eu-west-1:123456789012:secret:restate/license-token-AbCdEf",
+);
+
+const cluster = new RestateEcsFargateCluster(this, "restate-byoc", {
+  licenseKey: "00000000-0000-0000-0000-000000000000",
+  licenseToken: cdk.aws_ecs.Secret.fromSecretsManager(licenseTokenSecret),
+  vpc,
+});
+```
+
+The construct grants the controller's execution role permission to read the secret at task start. When you rotate the token (for example before the current one expires), update the secret value and restart the controller service to pick up the new value.
+
 ## Deploying services
 
 The [`@restatedev/restate-cdk`](https://www.npmjs.com/package/@restatedev/restate-cdk) library provides a `ServiceDeployer` construct which you can use to register Lambda functions in your BYOC cluster. This is documented in the [Restate CDK Documentation](https://docs.restate.dev/deploy/lambda/cdk).

--- a/lib/byoc.ts
+++ b/lib/byoc.ts
@@ -601,6 +601,7 @@ export class RestateEcsFargateCluster
     const controller = createController(
       this,
       props.licenseKey,
+      props.licenseToken,
       bucketPath,
       this.ecsCluster,
       ctPrefix,
@@ -1286,6 +1287,7 @@ function createTargetProps(
 function createController(
   scope: Construct,
   licenseKey: string,
+  licenseToken: cdk.aws_ecs.Secret | undefined,
   bucketPath: `s3://${string}`,
   cluster: cdk.aws_ecs.ICluster,
   clusterTaskPrefix: string,
@@ -1457,6 +1459,9 @@ function createController(
       RUST_LOG: "info,restate_fargate_controller=debug",
       ...config,
     },
+    secrets: licenseToken
+      ? { CONTROLLER_LICENSE_TOKEN: licenseToken }
+      : undefined,
   });
 
   taskDefinition.taskRole.addToPrincipalPolicy(

--- a/lib/props.ts
+++ b/lib/props.ts
@@ -11,6 +11,23 @@ export interface ClusterProps {
    * occasionally validate the product license by contacting <https://license.restate.cloud>.
    */
   licenseKey: string;
+
+  /**
+   * Optional pre-issued license JWT for offline operation. When set, the controller validates the
+   * token locally on startup and never contacts <https://license.restate.cloud>. The token must
+   * be signed for the same `licenseKey` (its `sub` claim must equal `licenseKey` exactly), and
+   * the controller exits when the token expires.
+   *
+   * The token is sensitive material; wire it via Secrets Manager or SSM Parameter Store using
+   * `cdk.aws_ecs.Secret`, for example:
+   *
+   * ```
+   * licenseToken: cdk.aws_ecs.Secret.fromSecretsManager(myJwtSecret)
+   * ```
+   *
+   * Default: not set; the controller contacts license.restate.cloud to acquire a license
+   */
+  licenseToken?: cdk.aws_ecs.Secret;
   /**
    * The VPC in which to run the cluster
    */

--- a/test/byoc.test.ts
+++ b/test/byoc.test.ts
@@ -690,6 +690,60 @@ describe("BYOC", () => {
       yaml: true,
     });
   });
+
+  test("License token from Secrets Manager", () => {
+    const { stack, vpc } = createStack();
+
+    const licenseTokenSecret = new cdk.aws_secretsmanager.Secret(
+      stack,
+      "license-token",
+      {
+        description: "Pre-issued Restate BYOC license JWT for offline operation",
+      },
+    );
+
+    new RestateEcsFargateCluster(stack, "with-license-token", {
+      vpc,
+      licenseKey,
+      licenseToken: cdk.aws_ecs.Secret.fromSecretsManager(licenseTokenSecret),
+    });
+
+    const template = cdk.assertions.Template.fromStack(stack);
+
+    // The controller container exposes CONTROLLER_LICENSE_TOKEN as a secret, not a plain env var.
+    template.hasResourceProperties("AWS::ECS::TaskDefinition", {
+      ContainerDefinitions: cdk.assertions.Match.arrayWith([
+        cdk.assertions.Match.objectLike({
+          Name: "controller",
+          Secrets: [
+            cdk.assertions.Match.objectLike({
+              Name: "CONTROLLER_LICENSE_TOKEN",
+              ValueFrom: {
+                Ref: cdk.assertions.Match.stringLikeRegexp("licensetoken.*"),
+              },
+            }),
+          ],
+        }),
+      ]),
+    });
+
+    // The controller execution role can read the secret at task start.
+    template.hasResourceProperties("AWS::IAM::Policy", {
+      PolicyDocument: {
+        Statement: cdk.assertions.Match.arrayWith([
+          cdk.assertions.Match.objectLike({
+            Action: cdk.assertions.Match.arrayWith([
+              "secretsmanager:GetSecretValue",
+            ]),
+            Effect: "Allow",
+            Resource: {
+              Ref: cdk.assertions.Match.stringLikeRegexp("licensetoken.*"),
+            },
+          }),
+        ]),
+      },
+    });
+  });
 });
 
 function createStack(): { stack: cdk.Stack; vpc: cdk.aws_ec2.IVpc } {


### PR DESCRIPTION
## Summary

- Adds optional `licenseToken?: cdk.aws_ecs.Secret` to `ClusterProps`. Pairs with [restate-fargate-controller#31](https://github.com/restatedev/restate-fargate-controller/pull/31), which added a `CONTROLLER_LICENSE_TOKEN` env var that lets the controller skip the call to `license.restate.cloud` and validate a pre-issued JWT locally instead. Useful for clusters with no outbound access to the license server.
- Type is `aws_ecs.Secret` rather than a plain string so the JWT is wired through Secrets Manager (or SSM Parameter Store) and fetched at task start instead of being baked into the CloudFormation template. The construct auto-grants `secretsmanager:GetSecretValue` to the controller execution role.
- The existing `licenseKey` UUID prop stays required; the controller enforces that the token's `sub` claim equals it.
- Docs: new "Offline operation with a pre-issued license token" subsection in `docs/index.md` with a worked example using `Secret.fromSecretCompleteArn` and a note on rotation.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npx jest` all 25 tests pass (13 snapshots unchanged)
- [x] New test "License token from Secrets Manager" asserts:
  - controller container has `Secrets: [{ Name: CONTROLLER_LICENSE_TOKEN, ValueFrom: <secret ref> }]`
  - controller execution role IAM policy grants `secretsmanager:GetSecretValue` on the referenced secret
- [ ] Manual: deploy a stack with a real pre-issued JWT, confirm controller logs show inline mode and no requests to `license.restate.cloud`
- [ ] Manual: rotate the secret value, restart the controller service, confirm pickup