### PR TITLE
Add @restatedev/byoc-artifacts as an opt-in distribution channel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,10 +33,22 @@ jobs:
       - name: Update package version for snapshot
         if: ${{ github.event_name == 'push' }}
         run: |
-          # We're using 0.0.0 to avoid this version to be higher than released versions.
-          # To use it:
-          # "@restatedev/byoc": "^0.0.0-SNAPSHOT"
-          npm version 0.0.0-SNAPSHOT-$(date '+%Y%m%d%H%M%S') --git-tag-version false
+          # 0.0.0 keeps snapshot versions below released versions.
+          # Consumers: "@restatedev/byoc": "^0.0.0-SNAPSHOT"
+          SNAPSHOT_VERSION=0.0.0-SNAPSHOT-$(date '+%Y%m%d%H%M%S')
+          npm version "$SNAPSHOT_VERSION" --workspaces --include-workspace-root --git-tag-version false
+      - name: Sync byoc-artifacts version with root
+        # On a release the root version is already set from the release tag; propagate it to the
+        # workspace so both packages always publish at the same version. (No-op for snapshots,
+        # which already synced above.)
+        run: |
+          ROOT_VERSION=$(node -p "require('./package.json').version")
+          npm version "$ROOT_VERSION" --workspace=@restatedev/byoc-artifacts --git-tag-version false --allow-same-version
+      - name: Pin byoc-artifacts peer dep to current version
+        # Keeps the optional peer-dep range in @restatedev/byoc in lockstep with whatever version
+        # @restatedev/byoc-artifacts is about to be published at.
+        run: |
+          node -e "const fs=require('fs');const p=require('./package.json');p.peerDependencies['@restatedev/byoc-artifacts']=p.version;fs.writeFileSync('./package.json', JSON.stringify(p, null, 2) + '\n');"
       - run: npm run publish-stack
         env:
           AWS_REGION: eu-central-1
@@ -51,16 +63,20 @@ jobs:
           retention-days: 1
           if-no-files-found: error
       - name: Publish to npm
+        # Publishes @restatedev/byoc-artifacts first so the peer-dep is resolvable when consumers
+        # install @restatedev/byoc and opt into `artifacts: { bundled: true }`.
         run: |
           if [[ "${{ github.event_name }}" == "push" ]]; then
-            # We use dist-tag dev for the snapshot releases, see https://docs.npmjs.com/cli/v9/commands/npm-dist-tag for more info
-            # A snapshot MUST not be published with latest tag (omitting --tag defaults to latest) to avoid users to install snapshot releases
-            # when using npm install
-            npm publish --tag dev --access public
+            # dist-tag dev for snapshots, see https://docs.npmjs.com/cli/v9/commands/npm-dist-tag
+            # Snapshots MUST NOT be published with the latest tag (default of `npm publish`)
+            # or `npm install` will pull them in.
+            DIST_TAG=dev
           elif [[ "${{ github.event.release.prerelease }}" == "true" ]]; then
-            npm publish --tag next --access public
+            DIST_TAG=next
           else
-            npm publish --tag latest --access public
+            DIST_TAG=latest
           fi
+          npm publish --workspace=@restatedev/byoc-artifacts --tag "$DIST_TAG" --access public
+          npm publish --tag "$DIST_TAG" --access public
         env:
           NODE_AUTH_TOKEN: ""

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 *.js
 !jest.config.js
 *.d.ts
+!byoc-artifacts/index.d.ts
 node_modules
+
+# Built Lambda artifacts populated by artifacts/upload.sh
+byoc-artifacts/*.zip
 
 # CDK asset staging directory
 .cdk.staging

--- a/artifacts/upload.sh
+++ b/artifacts/upload.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+REPO_ROOT="$SCRIPT_DIR/.."
+ARTIFACTS_PKG="$REPO_ROOT/byoc-artifacts"
 VERSION=$1
 
-rm $SCRIPT_DIR/*.zip
+rm -f "$ARTIFACTS_PKG"/*.zip
 
-zip -jr $SCRIPT_DIR/cloudwatch-custom-widget.zip $SCRIPT_DIR/../dist/lambda/cloudwatch-custom-widget/*.mjs
-zip -jr $SCRIPT_DIR/restatectl.zip  $SCRIPT_DIR/../lib/lambda/restatectl
-zip -jr $SCRIPT_DIR/retirement-watcher.zip  $SCRIPT_DIR/../dist/lambda/retirement-watcher/*.mjs
+zip -jr "$ARTIFACTS_PKG/cloudwatch-custom-widget.zip" "$REPO_ROOT"/dist/lambda/cloudwatch-custom-widget/*.mjs
+zip -jr "$ARTIFACTS_PKG/restatectl.zip"               "$REPO_ROOT"/lib/lambda/restatectl
+zip -jr "$ARTIFACTS_PKG/retirement-watcher.zip"       "$REPO_ROOT"/dist/lambda/retirement-watcher/*.mjs
 
-aws s3 mv $SCRIPT_DIR/cloudwatch-custom-widget.zip s3://restate-byoc-artifacts-public-eu-central-1/${VERSION}/assets/
-aws s3 mv $SCRIPT_DIR/restatectl.zip s3://restate-byoc-artifacts-public-eu-central-1/${VERSION}/assets/
-aws s3 mv $SCRIPT_DIR/retirement-watcher.zip s3://restate-byoc-artifacts-public-eu-central-1/${VERSION}/assets/
+aws s3 cp "$ARTIFACTS_PKG/cloudwatch-custom-widget.zip" "s3://restate-byoc-artifacts-public-eu-central-1/${VERSION}/assets/"
+aws s3 cp "$ARTIFACTS_PKG/restatectl.zip"               "s3://restate-byoc-artifacts-public-eu-central-1/${VERSION}/assets/"
+aws s3 cp "$ARTIFACTS_PKG/retirement-watcher.zip"       "s3://restate-byoc-artifacts-public-eu-central-1/${VERSION}/assets/"

--- a/byoc-artifacts/README.md
+++ b/byoc-artifacts/README.md
@@ -1,0 +1,22 @@
+# @restatedev/byoc-artifacts
+
+Pre-built Lambda artifact zips shipped alongside [`@restatedev/byoc`](https://www.npmjs.com/package/@restatedev/byoc):
+
+- `retirement-watcher.zip` - handles AWS Health Fargate task retirement notifications
+- `restatectl.zip` - Lambda wrapper around `restatectl` that targets the cluster from outside the VPC
+- `cloudwatch-custom-widget.zip` - handler for the CloudWatch operational dashboards
+
+The version of this package must match `@restatedev/byoc` exactly. It is declared as an optional peer dependency, so npm will not install it automatically: opt in by adding both packages to your project at the same version.
+
+```sh
+npm install @restatedev/byoc @restatedev/byoc-artifacts
+```
+
+This package exists so that the construct can resolve the Lambda assets through the normal CDK asset pipeline (uploads to your own CDK bootstrap bucket at synth time) instead of pulling them from a Restate-owned public S3 bucket at deploy time. The S3 distribution remains available as an override; see the `artifacts` prop in `@restatedev/byoc`.
+
+## Programmatic use
+
+```js
+const { retirementWatcher, restatectl, cloudwatchCustomWidget } = require("@restatedev/byoc-artifacts");
+// each is an absolute filesystem path to a .zip file
+```

--- a/byoc-artifacts/index.cjs
+++ b/byoc-artifacts/index.cjs
@@ -1,0 +1,11 @@
+"use strict";
+
+const path = require("node:path");
+
+const here = (file) => path.join(__dirname, file);
+
+module.exports = {
+  retirementWatcher: here("retirement-watcher.zip"),
+  restatectl: here("restatectl.zip"),
+  cloudwatchCustomWidget: here("cloudwatch-custom-widget.zip"),
+};

--- a/byoc-artifacts/index.d.ts
+++ b/byoc-artifacts/index.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Absolute filesystem paths to the Lambda artifact zips bundled with this package.
+ *
+ * Intended for use with `cdk.aws_lambda.Code.fromAsset(...)` from `@restatedev/byoc`.
+ * The version of this package must match `@restatedev/byoc` exactly.
+ */
+export declare const retirementWatcher: string;
+export declare const restatectl: string;
+export declare const cloudwatchCustomWidget: string;

--- a/byoc-artifacts/package.json
+++ b/byoc-artifacts/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@restatedev/byoc-artifacts",
+  "version": "0.5.0",
+  "description": "Pre-built Lambda artifacts (restatectl wrapper, retirement watcher, CloudWatch custom widget) used by @restatedev/byoc. Distributed via npm so the construct does not need to fetch them from a public S3 bucket at deploy time.",
+  "author": "Restate Developers",
+  "license": "MIT",
+  "homepage": "https://github.com/restatedev/byoc#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/restatedev/byoc.git",
+    "directory": "byoc-artifacts"
+  },
+  "bugs": {
+    "url": "https://github.com/restatedev/byoc/issues"
+  },
+  "type": "commonjs",
+  "main": "./index.cjs",
+  "types": "./index.d.ts",
+  "files": [
+    "index.cjs",
+    "index.d.ts",
+    "retirement-watcher.zip",
+    "restatectl.zip",
+    "cloudwatch-custom-widget.zip"
+  ]
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -321,6 +321,22 @@ The construct pulls a few small Lambda artifacts (the retirement watcher, the `r
    });
    ```
 
+3. **Bundle the artifacts via npm** by installing the optional peer dependency `@restatedev/byoc-artifacts` at the same version as `@restatedev/byoc` and setting `artifacts: { bundled: true }`. CDK then uploads the Lambda zips to your own CDK bootstrap bucket at synth time, so no public-bucket egress is needed at deploy time. This is useful when your deploy account can reach `registry.npmjs.org` but cannot reach the BYOC artifact bucket. The two packages are versioned in lockstep; the artifacts package adds a small amount of disk to your `node_modules` (the three zips, on the order of a few megabytes).
+
+   ```sh
+   npm install @restatedev/byoc @restatedev/byoc-artifacts
+   ```
+
+   ```ts
+   new RestateEcsFargateCluster(this, "restate-byoc", {
+     licenseKey: "...",
+     vpc,
+     artifacts: { bundled: true },
+   });
+   ```
+
+   Upgrade both packages together: the peer-dep version pin is exact, so installing only one of them will surface an `npm` peer-dep warning (and a hard error on pnpm/yarn-strict).
+
 # Appendix A: RestateEcsFargateCluster construct reference
 
 ```ts

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,7 +22,7 @@ export default defineConfig([
     },
   },
   {
-    ignores: ["dist/*", "jest.config.js", "cdk.out"],
+    ignores: ["dist/*", "jest.config.js", "cdk.out", "byoc-artifacts/*"],
   },
   tseslint.configs.recommended,
 ]);

--- a/lib/artifacts.ts
+++ b/lib/artifacts.ts
@@ -2,12 +2,20 @@ import * as cdk from "aws-cdk-lib";
 import { Construct } from "constructs";
 import * as path from "node:path";
 
+export type ArtifactsOverride =
+  | { bucket: cdk.aws_s3.IBucket; prefix?: string }
+  | { bundled: true };
+
 export function getArtifacts(
   scope: Construct,
   version: string,
-  override?: { bucket: cdk.aws_s3.IBucket; prefix?: string },
+  override?: ArtifactsOverride,
 ): Record<string, cdk.aws_lambda.Code> {
-  const artifactsBucket =
+  if (override && "bundled" in override) {
+    return bundledArtifacts(version);
+  }
+
+  const bucket =
     override?.bucket ??
     cdk.aws_s3.Bucket.fromBucketName(
       scope,
@@ -18,15 +26,15 @@ export function getArtifacts(
 
   return {
     "retirement-watcher.zip": cdk.aws_lambda.Code.fromBucketV2(
-      artifactsBucket,
+      bucket,
       `${prefix}${version}/assets/retirement-watcher.zip`,
     ),
     "restatectl.zip": cdk.aws_lambda.Code.fromBucketV2(
-      artifactsBucket,
+      bucket,
       `${prefix}${version}/assets/restatectl.zip`,
     ),
     "cloudwatch-custom-widget.zip": cdk.aws_lambda.Code.fromBucketV2(
-      artifactsBucket,
+      bucket,
       `${prefix}${version}/assets/cloudwatch-custom-widget.zip`,
     ),
   };
@@ -42,6 +50,45 @@ export function bundleArtifacts(): Record<string, cdk.aws_lambda.Code> {
     ),
     "cloudwatch-custom-widget.zip": cdk.aws_lambda.Code.fromAsset(
       path.join(__dirname, "../dist/lambda/cloudwatch-custom-widget"),
+    ),
+  };
+}
+
+function bundledArtifacts(
+  expectedVersion: string,
+): Record<string, cdk.aws_lambda.Code> {
+  let paths: {
+    retirementWatcher: string;
+    restatectl: string;
+    cloudwatchCustomWidget: string;
+  };
+  let artifactsPkg: { version: string };
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    paths = require("@restatedev/byoc-artifacts");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    artifactsPkg = require("@restatedev/byoc-artifacts/package.json");
+  } catch {
+    throw new Error(
+      "`artifacts: { bundled: true }` requires the optional peer dependency " +
+        "`@restatedev/byoc-artifacts` to be installed at the same version as " +
+        "`@restatedev/byoc`. Run: npm install @restatedev/byoc-artifacts",
+    );
+  }
+  if (artifactsPkg.version !== expectedVersion) {
+    throw new Error(
+      `@restatedev/byoc-artifacts@${artifactsPkg.version} is installed but ` +
+        `@restatedev/byoc@${expectedVersion} requires an exact version match. ` +
+        `Upgrade both packages together.`,
+    );
+  }
+  return {
+    "retirement-watcher.zip": cdk.aws_lambda.Code.fromAsset(
+      paths.retirementWatcher,
+    ),
+    "restatectl.zip": cdk.aws_lambda.Code.fromAsset(paths.restatectl),
+    "cloudwatch-custom-widget.zip": cdk.aws_lambda.Code.fromAsset(
+      paths.cloudwatchCustomWidget,
     ),
   };
 }

--- a/lib/byoc.ts
+++ b/lib/byoc.ts
@@ -615,7 +615,12 @@ export class RestateEcsFargateCluster
     );
     this.controller = controller;
 
-    if (props.artifacts?.prefix && !props.artifacts.prefix.endsWith("/")) {
+    if (
+      props.artifacts &&
+      "prefix" in props.artifacts &&
+      props.artifacts.prefix &&
+      !props.artifacts.prefix.endsWith("/")
+    ) {
       throw new Error(
         `artifacts.prefix must end with a "/" if set, got: ${props.artifacts.prefix}`,
       );

--- a/lib/props.ts
+++ b/lib/props.ts
@@ -135,25 +135,32 @@ export interface ClusterProps {
 
   /**
    * Override the source location for bundled Lambda artifacts (retirement watcher, restatectl,
-   * CloudWatch custom widget). Use this when the default public bucket
-   * `restate-byoc-artifacts-public-<region>` is unreachable in your environment, for example
-   * due to VPC endpoint policies, organization SCPs, or operating in a region without a mirror.
+   * CloudWatch custom widget). Two shapes are supported:
    *
-   * Mirror the contents of the public bucket into your own bucket; the construct will look up
-   * keys at `${prefix}<version>/assets/{retirement-watcher,restatectl,cloudwatch-custom-widget}.zip`.
-   * If you mirror the keys 1:1, omit `prefix`.
+   * - `{ bucket, prefix? }` - mirror the contents of the public bucket
+   *   `restate-byoc-artifacts-public-<region>` into your own bucket. The construct will look up
+   *   keys at `${prefix}<version>/assets/{retirement-watcher,restatectl,cloudwatch-custom-widget}.zip`.
+   *   Use this when the public bucket is unreachable (VPC endpoint policies, organization SCPs,
+   *   regions without a mirror).
    *
-   * Default: the BYOC public artifact bucket for the region
+   * - `{ bundled: true }` - load the artifacts from the optional peer dependency
+   *   `@restatedev/byoc-artifacts`. Install it explicitly at the same version as
+   *   `@restatedev/byoc`. CDK uploads the zips to your own bootstrap bucket at synth time as
+   *   part of the standard asset pipeline, so no public-bucket egress is required at deploy time.
+   *
+   * Default: the BYOC public artifact bucket for the region.
    */
-  artifacts?: {
-    bucket: cdk.aws_s3.IBucket;
-    /**
-     * Optional key prefix within the bucket. If set, must end with a `/`. For example, with
-     * `prefix: "restate-byoc/"` the construct reads `restate-byoc/<version>/assets/<name>.zip`.
-     * Default: no prefix (keys are mirrored 1:1 from the public bucket)
-     */
-    prefix?: string;
-  };
+  artifacts?:
+    | {
+        bucket: cdk.aws_s3.IBucket;
+        /**
+         * Optional key prefix within the bucket. If set, must end with a `/`. For example, with
+         * `prefix: "restate-byoc/"` the construct reads `restate-byoc/<version>/assets/<name>.zip`.
+         * Default: no prefix (keys are mirrored 1:1 from the public bucket)
+         */
+        prefix?: string;
+      }
+    | { bundled: true };
 
   /**
    * @internal

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "@restatedev/byoc",
       "version": "0.5.0",
       "license": "MIT",
+      "workspaces": [
+        "byoc-artifacts"
+      ],
       "devDependencies": {
         "@arethetypeswrong/cli": "^0.17.4",
         "@aws-cdk/toolkit-lib": "^1.2.4",
@@ -41,9 +44,20 @@
         "typescript-eslint": "^8.31.0"
       },
       "peerDependencies": {
+        "@restatedev/byoc-artifacts": "0.5.0",
         "aws-cdk-lib": "^2.0.0",
         "constructs": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@restatedev/byoc-artifacts": {
+          "optional": true
+        }
       }
+    },
+    "byoc-artifacts": {
+      "name": "@restatedev/byoc-artifacts",
+      "version": "0.5.0",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -340,7 +354,6 @@
       ],
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "jsonschema": "~1.4.1",
         "semver": "^7.7.2"
@@ -2365,7 +2378,6 @@
       "integrity": "sha512-DFbanx9jhjM+GejOJeLxIpX6riB+/a7cKk3ch4LS8JfuYMci1xv3+byOPLrtJpdFezOuabjOgvT6S59STweo4A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
@@ -8253,7 +8265,6 @@
       "integrity": "sha512-Yhp8+U4KFVQqL6phZ5yrHF5PdCvKWbYtLSS+egAfAW+N5w78amhbZcctervj59uqOZHMGDWXuDBklN+7eVfasg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -13097,7 +13108,6 @@
       "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
@@ -14830,6 +14840,10 @@
         "node": ">=14"
       }
     },
+    "node_modules/@restatedev/byoc-artifacts": {
+      "resolved": "byoc-artifacts",
+      "link": true
+    },
     "node_modules/@restatedev/restate-cdk": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@restatedev/restate-cdk/-/restate-cdk-1.5.0.tgz",
@@ -15868,7 +15882,6 @@
       "integrity": "sha512-jrTfRC7FM6nChvU7X2KqcrgquofrWLFDeYC1hKfwNWomVvrn7JIksqf344WN2X/y8xrgqBd2dJATZV4GbatBfg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.19.2"
       }
@@ -15940,7 +15953,6 @@
       "integrity": "sha512-67kYYShjBR0jNI5vsf/c3WG4u+zDnCTHTPqVMQguffaWWFs7artgwKmfwdifl+r6XyM5LYLas/dInj2T0SgJyw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.31.0",
         "@typescript-eslint/types": "8.31.0",
@@ -16143,7 +16155,6 @@
       "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -16429,7 +16440,6 @@
       "integrity": "sha512-rJa8QLd8WHaoTEjPLqVwmNpDMmyJycVaxdr/Evr/1MDLq+WCovP46IqPaXfH0q/jY0gCsga9or907tEayK5xcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -16459,7 +16469,6 @@
       ],
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@aws-cdk/asset-awscli-v1": "2.2.242",
         "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.0",
@@ -17049,7 +17058,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001688",
         "electron-to-chromium": "^1.5.73",
@@ -17421,8 +17429,7 @@
       "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.4.2.tgz",
       "integrity": "sha512-wsNxBlAott2qg8Zv87q3eYZYgheb9lchtBfjHzzLHtXbttwSrHPs1NNQbBrmbb1YZvYg2+Vh0Dor76w4mFxJkA==",
       "dev": true,
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -17515,6 +17522,7 @@
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -17746,7 +17754,6 @@
       "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -18176,6 +18183,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -18321,6 +18329,7 @@
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -18892,7 +18901,6 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -19786,7 +19794,6 @@
       "integrity": "sha512-jcByLnIFkd5gSXZmjNvS1TlmRhCXZjIzHYlaGkPlLIekG55JDR2Z4va9tZwCiP+/RDERiNhMOFu01xd6O5ct1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -19978,6 +19985,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -21268,7 +21276,6 @@
       "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -21391,7 +21398,6 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21560,6 +21566,7 @@
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "dist/*.js",
     "dist/*.d.ts"
   ],
+  "workspaces": [
+    "byoc-artifacts"
+  ],
   "scripts": {
     "attw": "attw --pack",
     "download-restatectl": "mkdir -p lib/lambda/restatectl && curl -L https://restate.gateway.scarf.sh/v1.6.2/restatectl-aarch64-unknown-linux-musl.tar.xz | tar -Jx --strip-components=1 -C lib/lambda/restatectl restatectl-aarch64-unknown-linux-musl/restatectl",
@@ -81,6 +84,12 @@
   },
   "peerDependencies": {
     "aws-cdk-lib": "^2.0.0",
-    "constructs": "^10.0.0"
+    "constructs": "^10.0.0",
+    "@restatedev/byoc-artifacts": "0.5.0"
+  },
+  "peerDependenciesMeta": {
+    "@restatedev/byoc-artifacts": {
+      "optional": true
+    }
   }
 }

--- a/test/byoc.test.ts
+++ b/test/byoc.test.ts
@@ -2,6 +2,8 @@ import * as cdk from "aws-cdk-lib";
 import "jest-cdk-snapshot";
 import { RestateEcsFargateCluster } from "../lib/byoc";
 import { aws_logs, aws_s3 } from "aws-cdk-lib";
+import * as fs from "node:fs";
+import * as path from "node:path";
 
 describe("BYOC", () => {
   const licenseKey = "foo";
@@ -74,6 +76,93 @@ describe("BYOC", () => {
           "^restate-byoc/[^/]+/assets/[^/]+\\.zip$",
         ),
       }),
+    });
+  });
+
+  test("With bundled artifacts", () => {
+    // The bundled opt-in resolves zip paths from @restatedev/byoc-artifacts and wires them in
+    // via Code.fromAsset, so CDK uploads them to the customer's bootstrap bucket at synth time
+    // instead of fetching from the public S3 bucket at deploy time.
+    const artifactsDir = path.dirname(
+      require.resolve("@restatedev/byoc-artifacts/package.json"),
+    );
+    const stubs = [
+      "retirement-watcher.zip",
+      "restatectl.zip",
+      "cloudwatch-custom-widget.zip",
+    ].map((name) => path.join(artifactsDir, name));
+    const createdStubs: string[] = [];
+    for (const stub of stubs) {
+      if (!fs.existsSync(stub)) {
+        fs.writeFileSync(stub, "");
+        createdStubs.push(stub);
+      }
+    }
+
+    try {
+      const { stack, vpc } = createStack();
+
+      new RestateEcsFargateCluster(stack, "with-bundled-artifacts", {
+        vpc,
+        licenseKey,
+        artifacts: { bundled: true },
+      });
+
+      const template = cdk.assertions.Template.fromStack(stack);
+      template.resourceCountIs("AWS::Lambda::Function", 3);
+      // Each Lambda's Code now points to an asset in the CDK bootstrap bucket - no
+      // restate-byoc-artifacts-public references anywhere in the template.
+      template.allResourcesProperties("AWS::Lambda::Function", {
+        Code: cdk.assertions.Match.objectLike({
+          S3Bucket: cdk.assertions.Match.anyValue(),
+          S3Key: cdk.assertions.Match.stringLikeRegexp("\\.zip$"),
+        }),
+      });
+      expect(JSON.stringify(template.toJSON())).not.toContain(
+        "restate-byoc-artifacts-public",
+      );
+    } finally {
+      for (const stub of createdStubs) fs.unlinkSync(stub);
+    }
+  });
+
+  test("Bundled opt-in rejects an artifacts package version mismatch", () => {
+    jest.isolateModules(() => {
+      jest.doMock("@restatedev/byoc-artifacts/package.json", () => ({
+        version: "9.9.9-totally-wrong",
+      }));
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { getArtifacts } = require("../lib/artifacts");
+
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, "mismatched-artifacts", {
+        env: { account: "account-id", region: "region" },
+      });
+
+      expect(() => getArtifacts(stack, "0.5.0", { bundled: true })).toThrow(
+        /9\.9\.9-totally-wrong.*0\.5\.0.*exact version match/s,
+      );
+    });
+  });
+
+  test("Bundled opt-in fails with a helpful message if peer dep is missing", () => {
+    // Simulate the peer dep being uninstalled. jest.isolateModules scopes the mock so it can't
+    // leak into other tests in this file.
+    jest.isolateModules(() => {
+      jest.doMock("@restatedev/byoc-artifacts", () => {
+        throw new Error("Cannot find module '@restatedev/byoc-artifacts'");
+      });
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { getArtifacts } = require("../lib/artifacts");
+
+      const app = new cdk.App();
+      const stack = new cdk.Stack(app, "missing-peer", {
+        env: { account: "account-id", region: "region" },
+      });
+
+      expect(() => getArtifacts(stack, "0.0.0", { bundled: true })).toThrow(
+        /requires the optional peer dependency `@restatedev\/byoc-artifacts`/,
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds a sibling npm package `@restatedev/byoc-artifacts` shipping the three Lambda zips (retirement watcher, `restatectl` wrapper, CloudWatch custom widget) so customers without S3 egress to the public BYOC bucket can pull them via npm instead.
- Default behaviour unchanged: `@restatedev/byoc` still fetches from `restate-byoc-artifacts-public-<region>` at deploy time. The existing `artifacts: { bucket, prefix? }` mirror override is unchanged. The new path is purely additive.
- Customers opt in by installing both packages at the same version and setting `artifacts: { bundled: true }`; the construct then loads the zips via `Code.fromAsset` from the optional peer dep, so CDK uploads them via the standard asset pipeline to the consumer's own bootstrap bucket.
- The `artifacts` prop becomes a discriminated union: `{ bucket, prefix? }` (existing S3 mirror) or `{ bundled: true }` (new opt-in).
- Optional peer dep is pinned to an exact version. The publish workflow now ships both packages from the same job, bumping versions via npm workspaces and patching the peer-dep pin in lockstep.

## What lands together

- `byoc-artifacts/{package.json, index.cjs, index.d.ts, README.md}` - new package
- `package.json` - workspaces + optional peer dep + `peerDependenciesMeta.optional: true`
- `lib/{artifacts.ts, byoc.ts, props.ts}` - discriminated union, narrowing for prefix validation, JSDoc for both shapes
- `test/byoc.test.ts` - new tests: "With bundled artifacts" (asserts every Lambda's Code points to an asset and template contains no `restate-byoc-artifacts-public` reference) and "Bundled opt-in fails with a helpful message if peer dep is missing" (uses `jest.isolateModules` + `jest.doMock`)
- `.github/workflows/publish.yml` - version sync via `npm version --workspaces --include-workspace-root`, peer-dep pin patch, publish artifacts package first
- `artifacts/upload.sh` - zips into `byoc-artifacts/` and `aws s3 cp` (was `mv`) so the npm pack step still has zips on disk
- `docs/index.md` - new option 3 under "Cannot reach the public Lambda artifact bucket"
- `.gitignore` - `!byoc-artifacts/index.d.ts`, `byoc-artifacts/*.zip`
- `eslint.config.mjs` - ignore `byoc-artifacts/*`

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npx jest` - 27 tests pass, 13 snapshots unchanged
- [x] New "With bundled artifacts" test asserts every Lambda Code is a CDK asset and synthesized template contains no `restate-byoc-artifacts-public` strings
- [x] New "Bundled opt-in fails with a helpful message" test asserts the error path when the peer dep is missing (`jest.isolateModules`)
- [x] Verified `npm version --workspaces --include-workspace-root` in a scratch repo bumps both packages but not the peer-dep range (handled by the `node -e` step in the workflow)
- [x] Verified `artifacts/publish_stack.mts` only reads `packageJson.version`, never writes - so the sync step's position in the workflow is correct for both push (snapshot) and release events

### What I'd still like to verify before this goes live

See review comment below for testing options that increase confidence on the publish workflow and end-to-end install flow.